### PR TITLE
php8.1: added new octal numbers syntax

### DIFF
--- a/internal/php8/scanner.go
+++ b/internal/php8/scanner.go
@@ -7003,7 +7003,7 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof77
 		}
 	st_case_77:
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 56 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 55 {
 			goto tr104
 		}
 		goto tr12
@@ -7023,7 +7023,7 @@ func (lex *Lexer) Lex() *token.Token {
 		if lex.data[(lex.p)] == 95 {
 			goto st77
 		}
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 56 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 55 {
 			goto tr104
 		}
 		goto tr304
@@ -24674,7 +24674,7 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof117
 		}
 	st_case_117:
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 56 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 55 {
 			goto tr171
 		}
 		goto tr168
@@ -24692,7 +24692,7 @@ func (lex *Lexer) Lex() *token.Token {
 		if lex.data[(lex.p)] == 95 {
 			goto st117
 		}
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 56 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 55 {
 			goto tr171
 		}
 		goto tr814

--- a/internal/php8/scanner.go
+++ b/internal/php8/scanner.go
@@ -10,26 +10,26 @@ import (
 )
 
 // line internal/php8/scanner.go:15
-const lexer_start int = 121
-const lexer_first_final int = 121
+const lexer_start int = 123
+const lexer_first_final int = 123
 const lexer_error int = 0
 
-const lexer_en_main int = 121
-const lexer_en_html int = 124
-const lexer_en_php int = 131
-const lexer_en_property int = 490
-const lexer_en_nowdoc int = 497
-const lexer_en_heredoc int = 501
-const lexer_en_backqote int = 508
-const lexer_en_template_string int = 514
-const lexer_en_heredoc_end int = 520
-const lexer_en_string_var int = 522
-const lexer_en_string_var_index int = 528
-const lexer_en_string_var_name int = 538
-const lexer_en_halt_compiller_open_parenthesis int = 540
-const lexer_en_halt_compiller_close_parenthesis int = 544
-const lexer_en_halt_compiller_close_semicolon int = 548
-const lexer_en_halt_compiller_end int = 552
+const lexer_en_main int = 123
+const lexer_en_html int = 126
+const lexer_en_php int = 133
+const lexer_en_property int = 493
+const lexer_en_nowdoc int = 500
+const lexer_en_heredoc int = 504
+const lexer_en_backqote int = 511
+const lexer_en_template_string int = 517
+const lexer_en_heredoc_end int = 523
+const lexer_en_string_var int = 525
+const lexer_en_string_var_index int = 531
+const lexer_en_string_var_name int = 542
+const lexer_en_halt_compiller_open_parenthesis int = 544
+const lexer_en_halt_compiller_close_parenthesis int = 548
+const lexer_en_halt_compiller_close_semicolon int = 552
+const lexer_en_halt_compiller_end int = 556
 
 // line internal/php8/scanner.rl:17
 
@@ -68,16 +68,12 @@ func (lex *Lexer) Lex() *token.Token {
 
 	_again:
 		switch lex.cs {
-		case 121:
-			goto st121
-		case 122:
-			goto st122
-		case 1:
-			goto st1
 		case 123:
 			goto st123
 		case 124:
 			goto st124
+		case 1:
+			goto st1
 		case 125:
 			goto st125
 		case 126:
@@ -88,32 +84,36 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st128
 		case 129:
 			goto st129
+		case 130:
+			goto st130
+		case 131:
+			goto st131
 		case 2:
 			goto st2
 		case 3:
 			goto st3
 		case 4:
 			goto st4
-		case 130:
-			goto st130
-		case 5:
-			goto st5
-		case 131:
-			goto st131
 		case 132:
 			goto st132
+		case 5:
+			goto st5
 		case 133:
 			goto st133
-		case 6:
-			goto st6
 		case 134:
 			goto st134
 		case 135:
 			goto st135
+		case 6:
+			goto st6
 		case 136:
 			goto st136
 		case 137:
 			goto st137
+		case 138:
+			goto st138
+		case 139:
+			goto st139
 		case 7:
 			goto st7
 		case 8:
@@ -122,10 +122,6 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st9
 		case 10:
 			goto st10
-		case 138:
-			goto st138
-		case 139:
-			goto st139
 		case 140:
 			goto st140
 		case 141:
@@ -138,12 +134,16 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st144
 		case 145:
 			goto st145
+		case 146:
+			goto st146
+		case 147:
+			goto st147
 		case 11:
 			goto st11
 		case 12:
 			goto st12
-		case 146:
-			goto st146
+		case 148:
+			goto st148
 		case 13:
 			goto st13
 		case 14:
@@ -254,114 +254,110 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st66
 		case 67:
 			goto st67
-		case 147:
-			goto st147
-		case 148:
-			goto st148
 		case 149:
 			goto st149
 		case 150:
 			goto st150
 		case 151:
 			goto st151
-		case 68:
-			goto st68
 		case 152:
 			goto st152
+		case 153:
+			goto st153
+		case 68:
+			goto st68
+		case 154:
+			goto st154
 		case 69:
 			goto st69
 		case 70:
 			goto st70
-		case 153:
-			goto st153
+		case 155:
+			goto st155
 		case 71:
 			goto st71
-		case 154:
-			goto st154
+		case 156:
+			goto st156
 		case 72:
 			goto st72
 		case 73:
 			goto st73
 		case 74:
 			goto st74
-		case 155:
-			goto st155
-		case 156:
-			goto st156
 		case 157:
 			goto st157
+		case 158:
+			goto st158
+		case 159:
+			goto st159
 		case 75:
 			goto st75
 		case 76:
 			goto st76
-		case 158:
-			goto st158
-		case 77:
-			goto st77
-		case 159:
-			goto st159
 		case 160:
 			goto st160
+		case 77:
+			goto st77
 		case 161:
 			goto st161
 		case 78:
 			goto st78
+		case 162:
+			goto st162
+		case 163:
+			goto st163
+		case 164:
+			goto st164
 		case 79:
 			goto st79
 		case 80:
 			goto st80
 		case 81:
 			goto st81
-		case 162:
-			goto st162
-		case 163:
-			goto st163
 		case 82:
 			goto st82
-		case 164:
-			goto st164
 		case 165:
 			goto st165
+		case 166:
+			goto st166
 		case 83:
 			goto st83
+		case 167:
+			goto st167
+		case 168:
+			goto st168
 		case 84:
 			goto st84
 		case 85:
 			goto st85
 		case 86:
 			goto st86
-		case 166:
-			goto st166
 		case 87:
 			goto st87
+		case 169:
+			goto st169
 		case 88:
 			goto st88
 		case 89:
 			goto st89
 		case 90:
 			goto st90
-		case 167:
-			goto st167
-		case 168:
-			goto st168
-		case 169:
-			goto st169
+		case 91:
+			goto st91
 		case 170:
 			goto st170
 		case 171:
 			goto st171
 		case 172:
 			goto st172
-		case 91:
-			goto st91
 		case 173:
 			goto st173
 		case 174:
 			goto st174
-		case 92:
-			goto st92
 		case 175:
 			goto st175
+		case 92:
+			goto st92
 		case 176:
 			goto st176
 		case 177:
@@ -374,6 +370,8 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st179
 		case 180:
 			goto st180
+		case 94:
+			goto st94
 		case 181:
 			goto st181
 		case 182:
@@ -392,16 +390,16 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st188
 		case 189:
 			goto st189
-		case 94:
-			goto st94
-		case 95:
-			goto st95
 		case 190:
 			goto st190
 		case 191:
 			goto st191
 		case 192:
 			goto st192
+		case 95:
+			goto st95
+		case 96:
+			goto st96
 		case 193:
 			goto st193
 		case 194:
@@ -712,14 +710,14 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st346
 		case 347:
 			goto st347
-		case 96:
-			goto st96
 		case 348:
 			goto st348
 		case 349:
 			goto st349
 		case 350:
 			goto st350
+		case 97:
+			goto st97
 		case 351:
 			goto st351
 		case 352:
@@ -860,8 +858,12 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st419
 		case 420:
 			goto st420
-		case 97:
-			goto st97
+		case 421:
+			goto st421
+		case 422:
+			goto st422
+		case 423:
+			goto st423
 		case 98:
 			goto st98
 		case 99:
@@ -872,18 +874,14 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st101
 		case 102:
 			goto st102
-		case 421:
-			goto st421
-		case 422:
-			goto st422
 		case 103:
 			goto st103
-		case 423:
-			goto st423
 		case 424:
 			goto st424
 		case 425:
 			goto st425
+		case 104:
+			goto st104
 		case 426:
 			goto st426
 		case 427:
@@ -1018,8 +1016,6 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st491
 		case 492:
 			goto st492
-		case 104:
-			goto st104
 		case 493:
 			goto st493
 		case 494:
@@ -1032,58 +1028,60 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st496
 		case 497:
 			goto st497
-		case 0:
-			goto st0
 		case 498:
 			goto st498
+		case 106:
+			goto st106
 		case 499:
 			goto st499
 		case 500:
 			goto st500
+		case 0:
+			goto st0
 		case 501:
 			goto st501
 		case 502:
 			goto st502
-		case 106:
-			goto st106
 		case 503:
 			goto st503
 		case 504:
 			goto st504
 		case 505:
 			goto st505
+		case 107:
+			goto st107
 		case 506:
 			goto st506
 		case 507:
 			goto st507
 		case 508:
 			goto st508
-		case 107:
-			goto st107
-		case 108:
-			goto st108
 		case 509:
 			goto st509
 		case 510:
 			goto st510
 		case 511:
 			goto st511
+		case 108:
+			goto st108
+		case 109:
+			goto st109
 		case 512:
 			goto st512
 		case 513:
 			goto st513
 		case 514:
 			goto st514
-		case 109:
-			goto st109
-		case 110:
-			goto st110
 		case 515:
 			goto st515
 		case 516:
 			goto st516
 		case 517:
 			goto st517
+		case 110:
+			goto st110
+		case 111:
+			goto st111
 		case 518:
 			goto st518
 		case 519:
@@ -1100,20 +1098,20 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st524
 		case 525:
 			goto st525
-		case 111:
-			goto st111
 		case 526:
 			goto st526
-		case 112:
-			goto st112
-		case 113:
-			goto st113
 		case 527:
 			goto st527
 		case 528:
 			goto st528
+		case 112:
+			goto st112
 		case 529:
 			goto st529
+		case 113:
+			goto st113
+		case 114:
+			goto st114
 		case 530:
 			goto st530
 		case 531:
@@ -1124,42 +1122,42 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st533
 		case 534:
 			goto st534
-		case 114:
-			goto st114
-		case 115:
-			goto st115
 		case 535:
 			goto st535
-		case 116:
-			goto st116
 		case 536:
 			goto st536
 		case 537:
 			goto st537
+		case 115:
+			goto st115
+		case 116:
+			goto st116
 		case 538:
 			goto st538
-		case 539:
-			goto st539
 		case 117:
 			goto st117
+		case 539:
+			goto st539
+		case 118:
+			goto st118
 		case 540:
 			goto st540
 		case 541:
 			goto st541
 		case 542:
 			goto st542
-		case 118:
-			goto st118
 		case 543:
 			goto st543
+		case 119:
+			goto st119
 		case 544:
 			goto st544
 		case 545:
 			goto st545
 		case 546:
 			goto st546
-		case 119:
-			goto st119
+		case 120:
+			goto st120
 		case 547:
 			goto st547
 		case 548:
@@ -1168,8 +1166,8 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st549
 		case 550:
 			goto st550
-		case 120:
-			goto st120
+		case 121:
+			goto st121
 		case 551:
 			goto st551
 		case 552:
@@ -1178,8 +1176,18 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st553
 		case 554:
 			goto st554
+		case 122:
+			goto st122
 		case 555:
 			goto st555
+		case 556:
+			goto st556
+		case 557:
+			goto st557
+		case 558:
+			goto st558
+		case 559:
+			goto st559
 		}
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -1187,16 +1195,12 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 	_resume:
 		switch lex.cs {
-		case 121:
-			goto st_case_121
-		case 122:
-			goto st_case_122
-		case 1:
-			goto st_case_1
 		case 123:
 			goto st_case_123
 		case 124:
 			goto st_case_124
+		case 1:
+			goto st_case_1
 		case 125:
 			goto st_case_125
 		case 126:
@@ -1207,32 +1211,36 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_128
 		case 129:
 			goto st_case_129
+		case 130:
+			goto st_case_130
+		case 131:
+			goto st_case_131
 		case 2:
 			goto st_case_2
 		case 3:
 			goto st_case_3
 		case 4:
 			goto st_case_4
-		case 130:
-			goto st_case_130
-		case 5:
-			goto st_case_5
-		case 131:
-			goto st_case_131
 		case 132:
 			goto st_case_132
+		case 5:
+			goto st_case_5
 		case 133:
 			goto st_case_133
-		case 6:
-			goto st_case_6
 		case 134:
 			goto st_case_134
 		case 135:
 			goto st_case_135
+		case 6:
+			goto st_case_6
 		case 136:
 			goto st_case_136
 		case 137:
 			goto st_case_137
+		case 138:
+			goto st_case_138
+		case 139:
+			goto st_case_139
 		case 7:
 			goto st_case_7
 		case 8:
@@ -1241,10 +1249,6 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_9
 		case 10:
 			goto st_case_10
-		case 138:
-			goto st_case_138
-		case 139:
-			goto st_case_139
 		case 140:
 			goto st_case_140
 		case 141:
@@ -1257,12 +1261,16 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_144
 		case 145:
 			goto st_case_145
+		case 146:
+			goto st_case_146
+		case 147:
+			goto st_case_147
 		case 11:
 			goto st_case_11
 		case 12:
 			goto st_case_12
-		case 146:
-			goto st_case_146
+		case 148:
+			goto st_case_148
 		case 13:
 			goto st_case_13
 		case 14:
@@ -1373,114 +1381,110 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_66
 		case 67:
 			goto st_case_67
-		case 147:
-			goto st_case_147
-		case 148:
-			goto st_case_148
 		case 149:
 			goto st_case_149
 		case 150:
 			goto st_case_150
 		case 151:
 			goto st_case_151
-		case 68:
-			goto st_case_68
 		case 152:
 			goto st_case_152
+		case 153:
+			goto st_case_153
+		case 68:
+			goto st_case_68
+		case 154:
+			goto st_case_154
 		case 69:
 			goto st_case_69
 		case 70:
 			goto st_case_70
-		case 153:
-			goto st_case_153
+		case 155:
+			goto st_case_155
 		case 71:
 			goto st_case_71
-		case 154:
-			goto st_case_154
+		case 156:
+			goto st_case_156
 		case 72:
 			goto st_case_72
 		case 73:
 			goto st_case_73
 		case 74:
 			goto st_case_74
-		case 155:
-			goto st_case_155
-		case 156:
-			goto st_case_156
 		case 157:
 			goto st_case_157
+		case 158:
+			goto st_case_158
+		case 159:
+			goto st_case_159
 		case 75:
 			goto st_case_75
 		case 76:
 			goto st_case_76
-		case 158:
-			goto st_case_158
-		case 77:
-			goto st_case_77
-		case 159:
-			goto st_case_159
 		case 160:
 			goto st_case_160
+		case 77:
+			goto st_case_77
 		case 161:
 			goto st_case_161
 		case 78:
 			goto st_case_78
+		case 162:
+			goto st_case_162
+		case 163:
+			goto st_case_163
+		case 164:
+			goto st_case_164
 		case 79:
 			goto st_case_79
 		case 80:
 			goto st_case_80
 		case 81:
 			goto st_case_81
-		case 162:
-			goto st_case_162
-		case 163:
-			goto st_case_163
 		case 82:
 			goto st_case_82
-		case 164:
-			goto st_case_164
 		case 165:
 			goto st_case_165
+		case 166:
+			goto st_case_166
 		case 83:
 			goto st_case_83
+		case 167:
+			goto st_case_167
+		case 168:
+			goto st_case_168
 		case 84:
 			goto st_case_84
 		case 85:
 			goto st_case_85
 		case 86:
 			goto st_case_86
-		case 166:
-			goto st_case_166
 		case 87:
 			goto st_case_87
+		case 169:
+			goto st_case_169
 		case 88:
 			goto st_case_88
 		case 89:
 			goto st_case_89
 		case 90:
 			goto st_case_90
-		case 167:
-			goto st_case_167
-		case 168:
-			goto st_case_168
-		case 169:
-			goto st_case_169
+		case 91:
+			goto st_case_91
 		case 170:
 			goto st_case_170
 		case 171:
 			goto st_case_171
 		case 172:
 			goto st_case_172
-		case 91:
-			goto st_case_91
 		case 173:
 			goto st_case_173
 		case 174:
 			goto st_case_174
-		case 92:
-			goto st_case_92
 		case 175:
 			goto st_case_175
+		case 92:
+			goto st_case_92
 		case 176:
 			goto st_case_176
 		case 177:
@@ -1493,6 +1497,8 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_179
 		case 180:
 			goto st_case_180
+		case 94:
+			goto st_case_94
 		case 181:
 			goto st_case_181
 		case 182:
@@ -1511,16 +1517,16 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_188
 		case 189:
 			goto st_case_189
-		case 94:
-			goto st_case_94
-		case 95:
-			goto st_case_95
 		case 190:
 			goto st_case_190
 		case 191:
 			goto st_case_191
 		case 192:
 			goto st_case_192
+		case 95:
+			goto st_case_95
+		case 96:
+			goto st_case_96
 		case 193:
 			goto st_case_193
 		case 194:
@@ -1831,14 +1837,14 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_346
 		case 347:
 			goto st_case_347
-		case 96:
-			goto st_case_96
 		case 348:
 			goto st_case_348
 		case 349:
 			goto st_case_349
 		case 350:
 			goto st_case_350
+		case 97:
+			goto st_case_97
 		case 351:
 			goto st_case_351
 		case 352:
@@ -1979,8 +1985,12 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_419
 		case 420:
 			goto st_case_420
-		case 97:
-			goto st_case_97
+		case 421:
+			goto st_case_421
+		case 422:
+			goto st_case_422
+		case 423:
+			goto st_case_423
 		case 98:
 			goto st_case_98
 		case 99:
@@ -1991,18 +2001,14 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_101
 		case 102:
 			goto st_case_102
-		case 421:
-			goto st_case_421
-		case 422:
-			goto st_case_422
 		case 103:
 			goto st_case_103
-		case 423:
-			goto st_case_423
 		case 424:
 			goto st_case_424
 		case 425:
 			goto st_case_425
+		case 104:
+			goto st_case_104
 		case 426:
 			goto st_case_426
 		case 427:
@@ -2137,8 +2143,6 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_491
 		case 492:
 			goto st_case_492
-		case 104:
-			goto st_case_104
 		case 493:
 			goto st_case_493
 		case 494:
@@ -2151,58 +2155,60 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_496
 		case 497:
 			goto st_case_497
-		case 0:
-			goto st_case_0
 		case 498:
 			goto st_case_498
+		case 106:
+			goto st_case_106
 		case 499:
 			goto st_case_499
 		case 500:
 			goto st_case_500
+		case 0:
+			goto st_case_0
 		case 501:
 			goto st_case_501
 		case 502:
 			goto st_case_502
-		case 106:
-			goto st_case_106
 		case 503:
 			goto st_case_503
 		case 504:
 			goto st_case_504
 		case 505:
 			goto st_case_505
+		case 107:
+			goto st_case_107
 		case 506:
 			goto st_case_506
 		case 507:
 			goto st_case_507
 		case 508:
 			goto st_case_508
-		case 107:
-			goto st_case_107
-		case 108:
-			goto st_case_108
 		case 509:
 			goto st_case_509
 		case 510:
 			goto st_case_510
 		case 511:
 			goto st_case_511
+		case 108:
+			goto st_case_108
+		case 109:
+			goto st_case_109
 		case 512:
 			goto st_case_512
 		case 513:
 			goto st_case_513
 		case 514:
 			goto st_case_514
-		case 109:
-			goto st_case_109
-		case 110:
-			goto st_case_110
 		case 515:
 			goto st_case_515
 		case 516:
 			goto st_case_516
 		case 517:
 			goto st_case_517
+		case 110:
+			goto st_case_110
+		case 111:
+			goto st_case_111
 		case 518:
 			goto st_case_518
 		case 519:
@@ -2219,20 +2225,20 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_524
 		case 525:
 			goto st_case_525
-		case 111:
-			goto st_case_111
 		case 526:
 			goto st_case_526
-		case 112:
-			goto st_case_112
-		case 113:
-			goto st_case_113
 		case 527:
 			goto st_case_527
 		case 528:
 			goto st_case_528
+		case 112:
+			goto st_case_112
 		case 529:
 			goto st_case_529
+		case 113:
+			goto st_case_113
+		case 114:
+			goto st_case_114
 		case 530:
 			goto st_case_530
 		case 531:
@@ -2243,42 +2249,42 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_533
 		case 534:
 			goto st_case_534
-		case 114:
-			goto st_case_114
-		case 115:
-			goto st_case_115
 		case 535:
 			goto st_case_535
-		case 116:
-			goto st_case_116
 		case 536:
 			goto st_case_536
 		case 537:
 			goto st_case_537
+		case 115:
+			goto st_case_115
+		case 116:
+			goto st_case_116
 		case 538:
 			goto st_case_538
-		case 539:
-			goto st_case_539
 		case 117:
 			goto st_case_117
+		case 539:
+			goto st_case_539
+		case 118:
+			goto st_case_118
 		case 540:
 			goto st_case_540
 		case 541:
 			goto st_case_541
 		case 542:
 			goto st_case_542
-		case 118:
-			goto st_case_118
 		case 543:
 			goto st_case_543
+		case 119:
+			goto st_case_119
 		case 544:
 			goto st_case_544
 		case 545:
 			goto st_case_545
 		case 546:
 			goto st_case_546
-		case 119:
-			goto st_case_119
+		case 120:
+			goto st_case_120
 		case 547:
 			goto st_case_547
 		case 548:
@@ -2287,8 +2293,8 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_549
 		case 550:
 			goto st_case_550
-		case 120:
-			goto st_case_120
+		case 121:
+			goto st_case_121
 		case 551:
 			goto st_case_551
 		case 552:
@@ -2297,79 +2303,89 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st_case_553
 		case 554:
 			goto st_case_554
+		case 122:
+			goto st_case_122
 		case 555:
 			goto st_case_555
+		case 556:
+			goto st_case_556
+		case 557:
+			goto st_case_557
+		case 558:
+			goto st_case_558
+		case 559:
+			goto st_case_559
 		}
 		goto st_out
 	tr0:
-		lex.cs = 121
-		// line internal/php8/scanner.rl:130
+		lex.cs = 123
+		// line internal/php8/scanner.rl:131
 		(lex.p) = (lex.te) - 1
 		{
-			lex.cs = 124
-			lex.ungetCnt(1)
-		}
-		goto _again
-	tr180:
-		lex.cs = 121
-		// line internal/php8/scanner.rl:130
-		lex.te = (lex.p) + 1
-		{
-			lex.cs = 124
+			lex.cs = 126
 			lex.ungetCnt(1)
 		}
 		goto _again
 	tr182:
-		lex.cs = 121
-		// line internal/php8/scanner.rl:130
-		lex.te = (lex.p)
-		(lex.p)--
+		lex.cs = 123
+		// line internal/php8/scanner.rl:131
+		lex.te = (lex.p) + 1
 		{
-			lex.cs = 124
+			lex.cs = 126
 			lex.ungetCnt(1)
 		}
 		goto _again
-	tr183:
+	tr184:
+		lex.cs = 123
+		// line internal/php8/scanner.rl:131
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.cs = 126
+			lex.ungetCnt(1)
+		}
+		goto _again
+	tr185:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:127
+		// line internal/php8/scanner.rl:128
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.addFreeFloatingToken(tkn, token.T_COMMENT, lex.ts, lex.te)
 		}
-		goto st121
-	st121:
+		goto st123
+	st123:
 		// line NONE:1
 		lex.ts = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof121
+			goto _test_eof123
 		}
-	st_case_121:
+	st_case_123:
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:2359
+		// line internal/php8/scanner.go:2375
 		if lex.data[(lex.p)] == 35 {
-			goto tr181
+			goto tr183
 		}
-		goto tr180
-	tr181:
+		goto tr182
+	tr183:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		goto st122
-	st122:
+		goto st124
+	st124:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof122
+			goto _test_eof124
 		}
-	st_case_122:
-		// line internal/php8/scanner.go:2374
+	st_case_124:
+		// line internal/php8/scanner.go:2390
 		if lex.data[(lex.p)] == 33 {
 			goto st1
 		}
-		goto tr182
+		goto tr184
 	tr3:
 		// line internal/php8/scanner.rl:38
 
@@ -2387,7 +2403,7 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof1
 		}
 	st_case_1:
-		// line internal/php8/scanner.go:2396
+		// line internal/php8/scanner.go:2412
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr2
@@ -2406,183 +2422,124 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st123
-	st123:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof123
-		}
-	st_case_123:
-		// line internal/php8/scanner.go:2421
-		goto tr183
-	tr4:
-		lex.cs = 124
-		// line internal/php8/scanner.rl:143
-		(lex.p) = (lex.te) - 1
-		{
-			lex.addFreeFloatingToken(tkn, token.T_OPEN_TAG, lex.ts, lex.te)
-			lex.cs = 131
-		}
-		goto _again
-	tr7:
-		lex.cs = 124
-		// line internal/php8/scanner.rl:147
-		lex.te = (lex.p) + 1
-		{
-			lex.ungetCnt(lex.te - lex.ts - 5)
-			lex.addFreeFloatingToken(tkn, token.T_OPEN_TAG, lex.ts, lex.ts+5)
-			lex.cs = 131
-		}
-		goto _again
-	tr188:
-		// line internal/php8/scanner.rl:137
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.ungetStr("<")
-			lex.setTokenPosition(tkn)
-			tok = token.T_INLINE_HTML
-			{
-				(lex.p)++
-				lex.cs = 124
-				goto _out
-			}
-		}
-		goto st124
-	tr190:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:137
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.ungetStr("<")
-			lex.setTokenPosition(tkn)
-			tok = token.T_INLINE_HTML
-			{
-				(lex.p)++
-				lex.cs = 124
-				goto _out
-			}
-		}
-		goto st124
-	tr196:
-		lex.cs = 124
-		// line internal/php8/scanner.rl:143
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.addFreeFloatingToken(tkn, token.T_OPEN_TAG, lex.ts, lex.te)
-			lex.cs = 131
-		}
-		goto _again
-	tr197:
-		lex.cs = 124
-		// line internal/php8/scanner.rl:152
-		lex.te = (lex.p) + 1
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_ECHO
-			lex.cs = 131
-			{
-				(lex.p)++
-				goto _out
-			}
-		}
-		goto _again
-	tr199:
-		lex.cs = 124
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:147
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.ungetCnt(lex.te - lex.ts - 5)
-			lex.addFreeFloatingToken(tkn, token.T_OPEN_TAG, lex.ts, lex.ts+5)
-			lex.cs = 131
-		}
-		goto _again
-	st124:
-		// line NONE:1
-		lex.ts = 0
-
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof124
-		}
-	st_case_124:
-		// line NONE:1
-		lex.ts = (lex.p)
-
-		// line internal/php8/scanner.go:2511
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr185
-		case 13:
-			goto tr186
-		case 60:
-			goto st128
-		}
-		goto st125
-	tr186:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st125
-	tr191:
-		// line internal/php8/scanner.rl:54
-
-		goto st125
-	tr193:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
 		goto st125
 	st125:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof125
 		}
 	st_case_125:
-		// line internal/php8/scanner.go:2556
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr185
-		case 13:
-			goto tr186
-		case 60:
-			goto st127
+		// line internal/php8/scanner.go:2437
+		goto tr185
+	tr4:
+		lex.cs = 126
+		// line internal/php8/scanner.rl:144
+		(lex.p) = (lex.te) - 1
+		{
+			lex.addFreeFloatingToken(tkn, token.T_OPEN_TAG, lex.ts, lex.te)
+			lex.cs = 133
 		}
-		goto st125
-	tr185:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
+		goto _again
+	tr7:
+		lex.cs = 126
+		// line internal/php8/scanner.rl:148
+		lex.te = (lex.p) + 1
+		{
+			lex.ungetCnt(lex.te - lex.ts - 5)
+			lex.addFreeFloatingToken(tkn, token.T_OPEN_TAG, lex.ts, lex.ts+5)
+			lex.cs = 133
 		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
+		goto _again
+	tr190:
+		// line internal/php8/scanner.rl:138
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.ungetStr("<")
+			lex.setTokenPosition(tkn)
+			tok = token.T_INLINE_HTML
+			{
+				(lex.p)++
+				lex.cs = 126
+				goto _out
+			}
 		}
-
 		goto st126
 	tr192:
 		// line internal/php8/scanner.rl:54
 
+		// line internal/php8/scanner.rl:138
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.ungetStr("<")
+			lex.setTokenPosition(tkn)
+			tok = token.T_INLINE_HTML
+			{
+				(lex.p)++
+				lex.cs = 126
+				goto _out
+			}
+		}
+		goto st126
+	tr198:
+		lex.cs = 126
+		// line internal/php8/scanner.rl:144
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.addFreeFloatingToken(tkn, token.T_OPEN_TAG, lex.ts, lex.te)
+			lex.cs = 133
+		}
+		goto _again
+	tr199:
+		lex.cs = 126
+		// line internal/php8/scanner.rl:153
+		lex.te = (lex.p) + 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_ECHO
+			lex.cs = 133
+			{
+				(lex.p)++
+				goto _out
+			}
+		}
+		goto _again
+	tr201:
+		lex.cs = 126
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:148
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.ungetCnt(lex.te - lex.ts - 5)
+			lex.addFreeFloatingToken(tkn, token.T_OPEN_TAG, lex.ts, lex.ts+5)
+			lex.cs = 133
+		}
+		goto _again
+	st126:
+		// line NONE:1
+		lex.ts = 0
+
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof126
+		}
+	st_case_126:
+		// line NONE:1
+		lex.ts = (lex.p)
+
+		// line internal/php8/scanner.go:2527
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr187
+		case 13:
+			goto tr188
+		case 60:
+			goto st130
+		}
+		goto st127
+	tr188:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -2593,24 +2550,23 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st126
-	st126:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof126
-		}
-	st_case_126:
-		// line internal/php8/scanner.go:2597
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr192
-		case 13:
-			goto tr193
-		case 60:
-			goto tr194
-		}
-		goto tr191
-	tr194:
+		goto st127
+	tr193:
 		// line internal/php8/scanner.rl:54
+
+		goto st127
+	tr195:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
 
 		goto st127
 	st127:
@@ -2618,37 +2574,59 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof127
 		}
 	st_case_127:
-		// line internal/php8/scanner.go:2616
+		// line internal/php8/scanner.go:2572
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr185
+			goto tr187
 		case 13:
-			goto tr186
-		case 60:
-			goto st127
-		case 63:
 			goto tr188
+		case 60:
+			goto st129
 		}
-		goto st125
+		goto st127
+	tr187:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st128
+	tr194:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st128
 	st128:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof128
 		}
 	st_case_128:
+		// line internal/php8/scanner.go:2613
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr185
+			goto tr194
 		case 13:
-			goto tr186
-		case 60:
-			goto st127
-		case 63:
 			goto tr195
+		case 60:
+			goto tr196
 		}
-		goto st125
-	tr195:
-		// line NONE:1
-		lex.te = (lex.p) + 1
+		goto tr193
+	tr196:
+		// line internal/php8/scanner.rl:54
 
 		goto st129
 	st129:
@@ -2656,16 +2634,54 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof129
 		}
 	st_case_129:
-		// line internal/php8/scanner.go:2654
+		// line internal/php8/scanner.go:2632
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr187
+		case 13:
+			goto tr188
+		case 60:
+			goto st129
+		case 63:
+			goto tr190
+		}
+		goto st127
+	st130:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof130
+		}
+	st_case_130:
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr187
+		case 13:
+			goto tr188
+		case 60:
+			goto st129
+		case 63:
+			goto tr197
+		}
+		goto st127
+	tr197:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st131
+	st131:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof131
+		}
+	st_case_131:
+		// line internal/php8/scanner.go:2670
 		switch lex.data[(lex.p)] {
 		case 61:
-			goto tr197
+			goto tr199
 		case 80:
 			goto st2
 		case 112:
 			goto st2
 		}
-		goto tr196
+		goto tr198
 	st2:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof2
@@ -2717,14 +2733,14 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st130
-	st130:
+		goto st132
+	st132:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof130
+			goto _test_eof132
 		}
-	st_case_130:
-		// line internal/php8/scanner.go:2721
-		goto tr199
+	st_case_132:
+		// line internal/php8/scanner.go:2737
+		goto tr201
 	tr9:
 		// line internal/php8/scanner.rl:38
 
@@ -2742,20 +2758,20 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof5
 		}
 	st_case_5:
-		// line internal/php8/scanner.go:2740
+		// line internal/php8/scanner.go:2756
 		if lex.data[(lex.p)] == 10 {
 			goto tr8
 		}
 		goto tr4
 	tr10:
-		// line internal/php8/scanner.rl:161
+		// line internal/php8/scanner.rl:162
 		(lex.p) = (lex.te) - 1
 		{
 			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
-		goto st131
+		goto st133
 	tr12:
-		lex.cs = 131
+		lex.cs = 133
 		// line NONE:1
 		switch lex.act {
 		case 10:
@@ -2772,7 +2788,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 
-				s := strings.Replace(string(lex.data[lex.ts+2:lex.te]), "_", "", -1)
+				s := strings.ReplaceAll(string(lex.data[lex.ts+2:lex.te]), "_", "")
 				_, err := strconv.ParseInt(s, 2, 0)
 
 				if err == nil {
@@ -2800,7 +2816,7 @@ func (lex *Lexer) Lex() *token.Token {
 					base = 8
 				}
 
-				s := strings.Replace(string(lex.data[lex.ts:lex.te]), "_", "", -1)
+				s := strings.ReplaceAll(string(lex.data[lex.ts:lex.te]), "_", "")
 				_, err := strconv.ParseInt(s, base, 0)
 
 				if err == nil {
@@ -2823,7 +2839,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 
-				s := strings.Replace(string(lex.data[lex.ts+2:lex.te]), "_", "", -1)
+				s := strings.ReplaceAll(string(lex.data[lex.ts+2:lex.te]), "_", "")
 				_, err := strconv.ParseInt(s, 16, 0)
 
 				if err == nil {
@@ -2845,8 +2861,21 @@ func (lex *Lexer) Lex() *token.Token {
 		case 14:
 			{
 				(lex.p) = (lex.te) - 1
+
+				s := strings.ReplaceAll(string(lex.data[lex.ts+2:lex.te]), "_", "")
+				_, err := strconv.ParseInt(s, 8, 0)
+
+				if err == nil {
+					lex.setTokenPosition(tkn)
+					tok = token.T_LNUMBER
+					{
+						(lex.p)++
+						goto _out
+					}
+				}
+
 				lex.setTokenPosition(tkn)
-				tok = token.T_NAME_RELATIVE
+				tok = token.T_DNUMBER
 				{
 					(lex.p)++
 					goto _out
@@ -2856,17 +2885,17 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_NAME_QUALIFIED
+				tok = token.T_NAME_RELATIVE
 				{
 					(lex.p)++
 					goto _out
 				}
 			}
-		case 18:
+		case 16:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ABSTRACT
+				tok = token.T_NAME_QUALIFIED
 				{
 					(lex.p)++
 					goto _out
@@ -2876,7 +2905,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ARRAY
+				tok = token.T_ABSTRACT
 				{
 					(lex.p)++
 					goto _out
@@ -2886,7 +2915,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_AS
+				tok = token.T_ARRAY
 				{
 					(lex.p)++
 					goto _out
@@ -2896,7 +2925,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_BREAK
+				tok = token.T_AS
 				{
 					(lex.p)++
 					goto _out
@@ -2906,7 +2935,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_CALLABLE
+				tok = token.T_BREAK
 				{
 					(lex.p)++
 					goto _out
@@ -2916,7 +2945,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_CASE
+				tok = token.T_CALLABLE
 				{
 					(lex.p)++
 					goto _out
@@ -2926,7 +2955,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_CATCH
+				tok = token.T_CASE
 				{
 					(lex.p)++
 					goto _out
@@ -2936,7 +2965,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_CLASS
+				tok = token.T_CATCH
 				{
 					(lex.p)++
 					goto _out
@@ -2946,7 +2975,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_CLONE
+				tok = token.T_CLASS
 				{
 					(lex.p)++
 					goto _out
@@ -2956,7 +2985,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_CONST
+				tok = token.T_CLONE
 				{
 					(lex.p)++
 					goto _out
@@ -2966,7 +2995,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_CONTINUE
+				tok = token.T_CONST
 				{
 					(lex.p)++
 					goto _out
@@ -2976,7 +3005,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_DECLARE
+				tok = token.T_CONTINUE
 				{
 					(lex.p)++
 					goto _out
@@ -2986,7 +3015,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_DEFAULT
+				tok = token.T_DECLARE
 				{
 					(lex.p)++
 					goto _out
@@ -2996,7 +3025,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_DO
+				tok = token.T_DEFAULT
 				{
 					(lex.p)++
 					goto _out
@@ -3006,7 +3035,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ECHO
+				tok = token.T_DO
 				{
 					(lex.p)++
 					goto _out
@@ -3016,7 +3045,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ELSE
+				tok = token.T_ECHO
 				{
 					(lex.p)++
 					goto _out
@@ -3026,7 +3055,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ELSEIF
+				tok = token.T_ELSE
 				{
 					(lex.p)++
 					goto _out
@@ -3036,7 +3065,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_EMPTY
+				tok = token.T_ELSEIF
 				{
 					(lex.p)++
 					goto _out
@@ -3046,7 +3075,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ENDDECLARE
+				tok = token.T_EMPTY
 				{
 					(lex.p)++
 					goto _out
@@ -3056,7 +3085,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ENDFOR
+				tok = token.T_ENDDECLARE
 				{
 					(lex.p)++
 					goto _out
@@ -3066,7 +3095,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ENDFOREACH
+				tok = token.T_ENDFOR
 				{
 					(lex.p)++
 					goto _out
@@ -3076,7 +3105,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ENDIF
+				tok = token.T_ENDFOREACH
 				{
 					(lex.p)++
 					goto _out
@@ -3086,7 +3115,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ENDSWITCH
+				tok = token.T_ENDIF
 				{
 					(lex.p)++
 					goto _out
@@ -3096,7 +3125,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ENDWHILE
+				tok = token.T_ENDSWITCH
 				{
 					(lex.p)++
 					goto _out
@@ -3106,7 +3135,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_EVAL
+				tok = token.T_ENDWHILE
 				{
 					(lex.p)++
 					goto _out
@@ -3116,7 +3145,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_EXIT
+				tok = token.T_EVAL
 				{
 					(lex.p)++
 					goto _out
@@ -3126,7 +3155,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_EXTENDS
+				tok = token.T_EXIT
 				{
 					(lex.p)++
 					goto _out
@@ -3136,7 +3165,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_FINAL
+				tok = token.T_EXTENDS
 				{
 					(lex.p)++
 					goto _out
@@ -3146,7 +3175,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_FINALLY
+				tok = token.T_FINAL
 				{
 					(lex.p)++
 					goto _out
@@ -3156,7 +3185,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_FOR
+				tok = token.T_FINALLY
 				{
 					(lex.p)++
 					goto _out
@@ -3166,7 +3195,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_FOREACH
+				tok = token.T_FOR
 				{
 					(lex.p)++
 					goto _out
@@ -3176,7 +3205,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_FUNCTION
+				tok = token.T_FOREACH
 				{
 					(lex.p)++
 					goto _out
@@ -3186,7 +3215,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_FN
+				tok = token.T_FUNCTION
 				{
 					(lex.p)++
 					goto _out
@@ -3196,7 +3225,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_GLOBAL
+				tok = token.T_FN
 				{
 					(lex.p)++
 					goto _out
@@ -3206,7 +3235,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_GOTO
+				tok = token.T_GLOBAL
 				{
 					(lex.p)++
 					goto _out
@@ -3216,7 +3245,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_IF
+				tok = token.T_GOTO
 				{
 					(lex.p)++
 					goto _out
@@ -3226,7 +3255,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_ISSET
+				tok = token.T_IF
 				{
 					(lex.p)++
 					goto _out
@@ -3236,7 +3265,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_IMPLEMENTS
+				tok = token.T_ISSET
 				{
 					(lex.p)++
 					goto _out
@@ -3246,7 +3275,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_INSTANCEOF
+				tok = token.T_IMPLEMENTS
 				{
 					(lex.p)++
 					goto _out
@@ -3256,7 +3285,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_INSTEADOF
+				tok = token.T_INSTANCEOF
 				{
 					(lex.p)++
 					goto _out
@@ -3266,7 +3295,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_INTERFACE
+				tok = token.T_INSTEADOF
 				{
 					(lex.p)++
 					goto _out
@@ -3276,7 +3305,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_LIST
+				tok = token.T_INTERFACE
 				{
 					(lex.p)++
 					goto _out
@@ -3286,7 +3315,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_NAMESPACE
+				tok = token.T_LIST
 				{
 					(lex.p)++
 					goto _out
@@ -3296,7 +3325,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_PRIVATE
+				tok = token.T_NAMESPACE
 				{
 					(lex.p)++
 					goto _out
@@ -3306,7 +3335,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_PUBLIC
+				tok = token.T_PRIVATE
 				{
 					(lex.p)++
 					goto _out
@@ -3316,7 +3345,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_PRINT
+				tok = token.T_PUBLIC
 				{
 					(lex.p)++
 					goto _out
@@ -3326,7 +3355,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_PROTECTED
+				tok = token.T_PRINT
 				{
 					(lex.p)++
 					goto _out
@@ -3336,7 +3365,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_RETURN
+				tok = token.T_PROTECTED
 				{
 					(lex.p)++
 					goto _out
@@ -3346,7 +3375,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_READONLY
+				tok = token.T_RETURN
 				{
 					(lex.p)++
 					goto _out
@@ -3356,7 +3385,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_STATIC
+				tok = token.T_READONLY
 				{
 					(lex.p)++
 					goto _out
@@ -3366,7 +3395,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_SWITCH
+				tok = token.T_STATIC
 				{
 					(lex.p)++
 					goto _out
@@ -3376,7 +3405,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_MATCH
+				tok = token.T_SWITCH
 				{
 					(lex.p)++
 					goto _out
@@ -3386,7 +3415,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_THROW
+				tok = token.T_MATCH
 				{
 					(lex.p)++
 					goto _out
@@ -3396,7 +3425,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_TRAIT
+				tok = token.T_THROW
 				{
 					(lex.p)++
 					goto _out
@@ -3406,7 +3435,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_TRY
+				tok = token.T_TRAIT
 				{
 					(lex.p)++
 					goto _out
@@ -3416,7 +3445,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_UNSET
+				tok = token.T_TRY
 				{
 					(lex.p)++
 					goto _out
@@ -3426,7 +3455,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_USE
+				tok = token.T_UNSET
 				{
 					(lex.p)++
 					goto _out
@@ -3436,7 +3465,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_VAR
+				tok = token.T_USE
 				{
 					(lex.p)++
 					goto _out
@@ -3446,17 +3475,17 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_WHILE
+				tok = token.T_VAR
 				{
 					(lex.p)++
 					goto _out
 				}
 			}
-		case 78:
+		case 77:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_YIELD
+				tok = token.T_WHILE
 				{
 					(lex.p)++
 					goto _out
@@ -3466,7 +3495,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_INCLUDE
+				tok = token.T_YIELD
 				{
 					(lex.p)++
 					goto _out
@@ -3476,7 +3505,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_INCLUDE_ONCE
+				tok = token.T_INCLUDE
 				{
 					(lex.p)++
 					goto _out
@@ -3486,7 +3515,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_REQUIRE
+				tok = token.T_INCLUDE_ONCE
 				{
 					(lex.p)++
 					goto _out
@@ -3496,7 +3525,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_REQUIRE_ONCE
+				tok = token.T_REQUIRE
 				{
 					(lex.p)++
 					goto _out
@@ -3506,7 +3535,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_CLASS_C
+				tok = token.T_REQUIRE_ONCE
 				{
 					(lex.p)++
 					goto _out
@@ -3516,7 +3545,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_DIR
+				tok = token.T_CLASS_C
 				{
 					(lex.p)++
 					goto _out
@@ -3526,7 +3555,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_FILE
+				tok = token.T_DIR
 				{
 					(lex.p)++
 					goto _out
@@ -3536,7 +3565,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_FUNC_C
+				tok = token.T_FILE
 				{
 					(lex.p)++
 					goto _out
@@ -3546,7 +3575,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_LINE
+				tok = token.T_FUNC_C
 				{
 					(lex.p)++
 					goto _out
@@ -3556,7 +3585,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_NS_C
+				tok = token.T_LINE
 				{
 					(lex.p)++
 					goto _out
@@ -3566,7 +3595,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_METHOD_C
+				tok = token.T_NS_C
 				{
 					(lex.p)++
 					goto _out
@@ -3576,7 +3605,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_TRAIT_C
+				tok = token.T_METHOD_C
 				{
 					(lex.p)++
 					goto _out
@@ -3586,8 +3615,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_HALT_COMPILER
-				lex.cs = 540
+				tok = token.T_TRAIT_C
 				{
 					(lex.p)++
 					goto _out
@@ -3597,7 +3625,8 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_NEW
+				tok = token.T_HALT_COMPILER
+				lex.cs = 544
 				{
 					(lex.p)++
 					goto _out
@@ -3607,7 +3636,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_LOGICAL_AND
+				tok = token.T_NEW
 				{
 					(lex.p)++
 					goto _out
@@ -3617,7 +3646,7 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
-				tok = token.T_LOGICAL_OR
+				tok = token.T_LOGICAL_AND
 				{
 					(lex.p)++
 					goto _out
@@ -3627,13 +3656,23 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
+				tok = token.T_LOGICAL_OR
+				{
+					(lex.p)++
+					goto _out
+				}
+			}
+		case 96:
+			{
+				(lex.p) = (lex.te) - 1
+				lex.setTokenPosition(tkn)
 				tok = token.T_LOGICAL_XOR
 				{
 					(lex.p)++
 					goto _out
 				}
 			}
-		case 124:
+		case 125:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
@@ -3643,7 +3682,7 @@ func (lex *Lexer) Lex() *token.Token {
 					goto _out
 				}
 			}
-		case 143:
+		case 144:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
@@ -3653,12 +3692,12 @@ func (lex *Lexer) Lex() *token.Token {
 					goto _out
 				}
 			}
-		case 149:
+		case 150:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
 				tok = token.ID(int('"'))
-				lex.cs = 514
+				lex.cs = 517
 				{
 					(lex.p)++
 					goto _out
@@ -3668,169 +3707,169 @@ func (lex *Lexer) Lex() *token.Token {
 
 		goto _again
 	tr15:
-		// line internal/php8/scanner.rl:361
+		// line internal/php8/scanner.rl:372
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_CONSTANT_ENCAPSED_STRING
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr19:
-		// line internal/php8/scanner.rl:384
+		// line internal/php8/scanner.rl:395
 		(lex.p) = (lex.te) - 1
 		{
 			c := lex.data[lex.p]
 			lex.error(fmt.Sprintf("WARNING: Unexpected character in input: '%c' (ASCII=%d)", c, c))
 		}
-		goto st131
+		goto st133
 	tr23:
-		// line internal/php8/scanner.rl:347
+		// line internal/php8/scanner.rl:358
 		(lex.p) = (lex.te) - 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int(lex.data[lex.ts]))
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr38:
-		// line internal/php8/scanner.rl:318
+		// line internal/php8/scanner.rl:329
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_ARRAY_CAST
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr45:
-		// line internal/php8/scanner.rl:324
+		// line internal/php8/scanner.rl:335
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_STRING_CAST
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr49:
-		// line internal/php8/scanner.rl:319
+		// line internal/php8/scanner.rl:330
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_BOOL_CAST
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr57:
-		// line internal/php8/scanner.rl:321
+		// line internal/php8/scanner.rl:332
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_DOUBLE_CAST
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr64:
-		// line internal/php8/scanner.rl:322
+		// line internal/php8/scanner.rl:333
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_INT_CAST
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr73:
-		// line internal/php8/scanner.rl:323
+		// line internal/php8/scanner.rl:334
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_OBJECT_CAST
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr77:
-		// line internal/php8/scanner.rl:320
+		// line internal/php8/scanner.rl:331
 		lex.te = (lex.p) + 1
 		{
 			lex.error(fmt.Sprintf("The (real) cast has been removed, use (float) instead"))
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr86:
-		// line internal/php8/scanner.rl:325
+		// line internal/php8/scanner.rl:336
 		lex.te = (lex.p) + 1
 		{
 			lex.error(fmt.Sprintf("The (unset) cast is no longer supported"))
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr87:
-		// line internal/php8/scanner.rl:286
+		// line internal/php8/scanner.rl:297
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_ELLIPSIS
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr90:
-		// line internal/php8/scanner.rl:165
+		// line internal/php8/scanner.rl:166
 		(lex.p) = (lex.te) - 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_DNUMBER
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
+		goto st133
 	tr100:
-		// line internal/php8/scanner.rl:334
+		// line internal/php8/scanner.rl:345
 		lex.te = (lex.p) + 1
 		{
 			isDocComment := false
@@ -3844,9 +3883,9 @@ func (lex *Lexer) Lex() *token.Token {
 				lex.addFreeFloatingToken(tkn, token.T_COMMENT, lex.ts, lex.te)
 			}
 		}
-		goto st131
+		goto st133
 	tr101:
-		// line internal/php8/scanner.rl:176
+		// line internal/php8/scanner.rl:177
 		(lex.p) = (lex.te) - 1
 		{
 			base := 10
@@ -3854,7 +3893,7 @@ func (lex *Lexer) Lex() *token.Token {
 				base = 8
 			}
 
-			s := strings.Replace(string(lex.data[lex.ts:lex.te]), "_", "", -1)
+			s := strings.ReplaceAll(string(lex.data[lex.ts:lex.te]), "_", "")
 			_, err := strconv.ParseInt(s, base, 0)
 
 			if err == nil {
@@ -3862,7 +3901,7 @@ func (lex *Lexer) Lex() *token.Token {
 				tok = token.T_LNUMBER
 				{
 					(lex.p)++
-					lex.cs = 131
+					lex.cs = 133
 					goto _out
 				}
 			}
@@ -3871,33 +3910,19 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_DNUMBER
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr114:
-		lex.cs = 131
-		// line internal/php8/scanner.rl:163
+		goto st133
+	tr115:
+		lex.cs = 133
+		// line internal/php8/scanner.rl:164
 		(lex.p) = (lex.te) - 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int(';'))
-			lex.cs = 124
-			{
-				(lex.p)++
-				goto _out
-			}
-		}
-		goto _again
-	tr130:
-		lex.cs = 131
-		// line internal/php8/scanner.rl:359
-		lex.te = (lex.p) + 1
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_NULLSAFE_OBJECT_OPERATOR
-			lex.cs = 490
+			lex.cs = 126
 			{
 				(lex.p)++
 				goto _out
@@ -3905,118 +3930,132 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		goto _again
 	tr131:
-		lex.cs = 131
-		// line internal/php8/scanner.rl:162
-		(lex.p) = (lex.te) - 1
+		lex.cs = 133
+		// line internal/php8/scanner.rl:370
+		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
-			tok = token.ID(int(';'))
-			lex.cs = 124
+			tok = token.T_NULLSAFE_OBJECT_OPERATOR
+			lex.cs = 493
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr134:
-		// line internal/php8/scanner.rl:356
+	tr132:
+		lex.cs = 133
+		// line internal/php8/scanner.rl:163
+		(lex.p) = (lex.te) - 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.ID(int(';'))
+			lex.cs = 126
+			{
+				(lex.p)++
+				goto _out
+			}
+		}
+		goto _again
+	tr135:
+		// line internal/php8/scanner.rl:367
 		(lex.p) = (lex.te) - 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_STRING
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr137:
-		// line internal/php8/scanner.rl:267
+		goto st133
+	tr138:
+		// line internal/php8/scanner.rl:278
 		(lex.p) = (lex.te) - 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_YIELD
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr148:
-		// line internal/php8/scanner.rl:266
+		goto st133
+	tr149:
+		// line internal/php8/scanner.rl:277
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_YIELD_FROM
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr149:
-		// line internal/php8/scanner.rl:204
+		goto st133
+	tr150:
+		// line internal/php8/scanner.rl:215
 		(lex.p) = (lex.te) - 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_NAME_FULLY_QUALIFIED
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr200:
-		// line internal/php8/scanner.rl:384
+		goto st133
+	tr202:
+		// line internal/php8/scanner.rl:395
 		lex.te = (lex.p) + 1
 		{
 			c := lex.data[lex.p]
 			lex.error(fmt.Sprintf("WARNING: Unexpected character in input: '%c' (ASCII=%d)", c, c))
 		}
-		goto st131
-	tr211:
-		// line internal/php8/scanner.rl:347
+		goto st133
+	tr213:
+		// line internal/php8/scanner.rl:358
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int(lex.data[lex.ts]))
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr249:
-		lex.cs = 131
-		// line internal/php8/scanner.rl:381
+		goto st133
+	tr251:
+		lex.cs = 133
+		// line internal/php8/scanner.rl:392
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int('`'))
-			lex.cs = 508
+			lex.cs = 511
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr250:
-		// line internal/php8/scanner.rl:353
+	tr252:
+		// line internal/php8/scanner.rl:364
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int('{'))
-			lex.call(131, 131)
+			lex.call(133, 133)
 			goto _out
 		}
-		goto st131
-	tr252:
-		// line internal/php8/scanner.rl:354
+		goto st133
+	tr254:
+		// line internal/php8/scanner.rl:365
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
@@ -4024,36 +4063,36 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.ret(1)
 			goto _out
 		}
-		goto st131
-	tr253:
-		// line internal/php8/scanner.rl:161
+		goto st133
+	tr255:
+		// line internal/php8/scanner.rl:162
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
-		goto st131
-	tr255:
+		goto st133
+	tr257:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:161
+		// line internal/php8/scanner.rl:162
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
-		goto st131
-	tr259:
-		// line internal/php8/scanner.rl:384
+		goto st133
+	tr261:
+		// line internal/php8/scanner.rl:395
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			c := lex.data[lex.p]
 			lex.error(fmt.Sprintf("WARNING: Unexpected character in input: '%c' (ASCII=%d)", c, c))
 		}
-		goto st131
-	tr260:
-		// line internal/php8/scanner.rl:347
+		goto st133
+	tr262:
+		// line internal/php8/scanner.rl:358
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4061,13 +4100,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.ID(int(lex.data[lex.ts]))
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr262:
-		// line internal/php8/scanner.rl:304
+		goto st133
+	tr264:
+		// line internal/php8/scanner.rl:315
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4075,82 +4114,82 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_IS_NOT_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr263:
-		// line internal/php8/scanner.rl:305
+		goto st133
+	tr265:
+		// line internal/php8/scanner.rl:316
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_IS_NOT_IDENTICAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr264:
-		lex.cs = 131
-		// line internal/php8/scanner.rl:382
+		goto st133
+	tr266:
+		lex.cs = 133
+		// line internal/php8/scanner.rl:393
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int('"'))
-			lex.cs = 514
+			lex.cs = 517
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr265:
-		// line internal/php8/scanner.rl:331
+	tr267:
+		// line internal/php8/scanner.rl:342
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.addFreeFloatingToken(tkn, token.T_COMMENT, lex.ts, lex.te)
 		}
-		goto st131
-	tr267:
-		// line internal/php8/scanner.rl:285
+		goto st133
+	tr269:
+		// line internal/php8/scanner.rl:296
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_ATTRIBUTE
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr268:
-		// line internal/php8/scanner.rl:327
+		goto st133
+	tr270:
+		// line internal/php8/scanner.rl:338
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.ungetStr("?>")
 			lex.addFreeFloatingToken(tkn, token.T_COMMENT, lex.ts, lex.te)
 		}
-		goto st131
-	tr271:
+		goto st133
+	tr273:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:327
+		// line internal/php8/scanner.rl:338
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.ungetStr("?>")
 			lex.addFreeFloatingToken(tkn, token.T_COMMENT, lex.ts, lex.te)
 		}
-		goto st131
-	tr276:
-		// line internal/php8/scanner.rl:355
+		goto st133
+	tr278:
+		// line internal/php8/scanner.rl:366
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4158,65 +4197,65 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_VARIABLE
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr277:
-		// line internal/php8/scanner.rl:299
+		goto st133
+	tr279:
+		// line internal/php8/scanner.rl:310
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_MOD_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr278:
-		// line internal/php8/scanner.rl:288
+		goto st133
+	tr280:
+		// line internal/php8/scanner.rl:299
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_BOOLEAN_AND
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr279:
-		// line internal/php8/scanner.rl:290
+		goto st133
+	tr281:
+		// line internal/php8/scanner.rl:301
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_AND_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr281:
-		// line internal/php8/scanner.rl:293
+		goto st133
+	tr283:
+		// line internal/php8/scanner.rl:304
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_MUL_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr282:
-		// line internal/php8/scanner.rl:312
+		goto st133
+	tr284:
+		// line internal/php8/scanner.rl:323
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4224,105 +4263,105 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_POW
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr283:
-		// line internal/php8/scanner.rl:294
+		goto st133
+	tr285:
+		// line internal/php8/scanner.rl:305
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_POW_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr284:
-		// line internal/php8/scanner.rl:301
+		goto st133
+	tr286:
+		// line internal/php8/scanner.rl:312
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_INC
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr285:
-		// line internal/php8/scanner.rl:296
+		goto st133
+	tr287:
+		// line internal/php8/scanner.rl:307
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_PLUS_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr286:
-		// line internal/php8/scanner.rl:300
+		goto st133
+	tr288:
+		// line internal/php8/scanner.rl:311
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_DEC
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr287:
-		// line internal/php8/scanner.rl:297
+		goto st133
+	tr289:
+		// line internal/php8/scanner.rl:308
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_MINUS_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr288:
-		lex.cs = 131
-		// line internal/php8/scanner.rl:358
+		goto st133
+	tr290:
+		lex.cs = 133
+		// line internal/php8/scanner.rl:369
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_OBJECT_OPERATOR
-			lex.cs = 490
+			lex.cs = 493
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr290:
-		// line internal/php8/scanner.rl:292
+	tr292:
+		// line internal/php8/scanner.rl:303
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_CONCAT_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr291:
-		// line internal/php8/scanner.rl:165
+		goto st133
+	tr293:
+		// line internal/php8/scanner.rl:166
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4330,26 +4369,26 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_DNUMBER
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr294:
-		// line internal/php8/scanner.rl:295
+		goto st133
+	tr296:
+		// line internal/php8/scanner.rl:306
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_DIV_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr295:
-		// line internal/php8/scanner.rl:176
+		goto st133
+	tr297:
+		// line internal/php8/scanner.rl:177
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4358,7 +4397,7 @@ func (lex *Lexer) Lex() *token.Token {
 				base = 8
 			}
 
-			s := strings.Replace(string(lex.data[lex.ts:lex.te]), "_", "", -1)
+			s := strings.ReplaceAll(string(lex.data[lex.ts:lex.te]), "_", "")
 			_, err := strconv.ParseInt(s, base, 0)
 
 			if err == nil {
@@ -4366,7 +4405,7 @@ func (lex *Lexer) Lex() *token.Token {
 				tok = token.T_LNUMBER
 				{
 					(lex.p)++
-					lex.cs = 131
+					lex.cs = 133
 					goto _out
 				}
 			}
@@ -4375,17 +4414,17 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_DNUMBER
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr300:
-		// line internal/php8/scanner.rl:166
+		goto st133
+	tr303:
+		// line internal/php8/scanner.rl:167
 		lex.te = (lex.p)
 		(lex.p)--
 		{
-			s := strings.Replace(string(lex.data[lex.ts+2:lex.te]), "_", "", -1)
+			s := strings.ReplaceAll(string(lex.data[lex.ts+2:lex.te]), "_", "")
 			_, err := strconv.ParseInt(s, 2, 0)
 
 			if err == nil {
@@ -4393,7 +4432,7 @@ func (lex *Lexer) Lex() *token.Token {
 				tok = token.T_LNUMBER
 				{
 					(lex.p)++
-					lex.cs = 131
+					lex.cs = 133
 					goto _out
 				}
 			}
@@ -4402,17 +4441,44 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_DNUMBER
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr301:
-		// line internal/php8/scanner.rl:191
+		goto st133
+	tr304:
+		// line internal/php8/scanner.rl:202
 		lex.te = (lex.p)
 		(lex.p)--
 		{
-			s := strings.Replace(string(lex.data[lex.ts+2:lex.te]), "_", "", -1)
+			s := strings.ReplaceAll(string(lex.data[lex.ts+2:lex.te]), "_", "")
+			_, err := strconv.ParseInt(s, 8, 0)
+
+			if err == nil {
+				lex.setTokenPosition(tkn)
+				tok = token.T_LNUMBER
+				{
+					(lex.p)++
+					lex.cs = 133
+					goto _out
+				}
+			}
+
+			lex.setTokenPosition(tkn)
+			tok = token.T_DNUMBER
+			{
+				(lex.p)++
+				lex.cs = 133
+				goto _out
+			}
+		}
+		goto st133
+	tr305:
+		// line internal/php8/scanner.rl:192
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			s := strings.ReplaceAll(string(lex.data[lex.ts+2:lex.te]), "_", "")
 			_, err := strconv.ParseInt(s, 16, 0)
 
 			if err == nil {
@@ -4420,7 +4486,7 @@ func (lex *Lexer) Lex() *token.Token {
 				tok = token.T_LNUMBER
 				{
 					(lex.p)++
-					lex.cs = 131
+					lex.cs = 133
 					goto _out
 				}
 			}
@@ -4429,71 +4495,71 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_DNUMBER
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr302:
-		// line internal/php8/scanner.rl:287
+		goto st133
+	tr306:
+		// line internal/php8/scanner.rl:298
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_PAAMAYIM_NEKUDOTAYIM
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr303:
-		lex.cs = 131
-		// line internal/php8/scanner.rl:163
+		goto st133
+	tr307:
+		lex.cs = 133
+		// line internal/php8/scanner.rl:164
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int(';'))
-			lex.cs = 124
+			lex.cs = 126
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr305:
-		lex.cs = 131
+	tr309:
+		lex.cs = 133
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:163
+		// line internal/php8/scanner.rl:164
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int(';'))
-			lex.cs = 124
+			lex.cs = 126
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr308:
-		// line internal/php8/scanner.rl:304
+	tr312:
+		// line internal/php8/scanner.rl:315
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_IS_NOT_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr309:
-		// line internal/php8/scanner.rl:313
+		goto st133
+	tr313:
+		// line internal/php8/scanner.rl:324
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4501,29 +4567,29 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_SL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr310:
-		// line internal/php8/scanner.rl:308
+		goto st133
+	tr314:
+		// line internal/php8/scanner.rl:319
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_SL_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr311:
-		lex.cs = 131
+		goto st133
+	tr315:
+		lex.cs = 133
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:367
+		// line internal/php8/scanner.rl:378
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4532,11 +4598,11 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_START_HEREDOC
 
 			if lex.isHeredocEnd(lex.p + 1) {
-				lex.cs = 520
+				lex.cs = 523
 			} else if lex.data[lblStart-1] == '\'' {
-				lex.cs = 497
+				lex.cs = 500
 			} else {
-				lex.cs = 501
+				lex.cs = 504
 			}
 			{
 				(lex.p)++
@@ -4544,8 +4610,8 @@ func (lex *Lexer) Lex() *token.Token {
 			}
 		}
 		goto _again
-	tr312:
-		// line internal/php8/scanner.rl:311
+	tr316:
+		// line internal/php8/scanner.rl:322
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4553,39 +4619,39 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_IS_SMALLER_OR_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr313:
-		// line internal/php8/scanner.rl:303
+		goto st133
+	tr317:
+		// line internal/php8/scanner.rl:314
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_SPACESHIP
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr315:
-		// line internal/php8/scanner.rl:302
+		goto st133
+	tr319:
+		// line internal/php8/scanner.rl:313
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_DOUBLE_ARROW
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr316:
-		// line internal/php8/scanner.rl:306
+		goto st133
+	tr320:
+		// line internal/php8/scanner.rl:317
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4593,39 +4659,39 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_IS_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr317:
-		// line internal/php8/scanner.rl:307
+		goto st133
+	tr321:
+		// line internal/php8/scanner.rl:318
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_IS_IDENTICAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr318:
-		// line internal/php8/scanner.rl:310
+		goto st133
+	tr322:
+		// line internal/php8/scanner.rl:321
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_IS_GREATER_OR_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr320:
-		// line internal/php8/scanner.rl:314
+		goto st133
+	tr324:
+		// line internal/php8/scanner.rl:325
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4633,58 +4699,58 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_SR
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr321:
-		// line internal/php8/scanner.rl:309
+		goto st133
+	tr325:
+		// line internal/php8/scanner.rl:320
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_SR_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr325:
-		lex.cs = 131
-		// line internal/php8/scanner.rl:162
+		goto st133
+	tr329:
+		lex.cs = 133
+		// line internal/php8/scanner.rl:163
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int(';'))
-			lex.cs = 124
+			lex.cs = 126
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr327:
-		lex.cs = 131
+	tr331:
+		lex.cs = 133
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:162
+		// line internal/php8/scanner.rl:163
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int(';'))
-			lex.cs = 124
+			lex.cs = 126
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr328:
-		// line internal/php8/scanner.rl:315
+	tr332:
+		// line internal/php8/scanner.rl:326
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4692,26 +4758,26 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_COALESCE
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr329:
-		// line internal/php8/scanner.rl:316
+		goto st133
+	tr333:
+		// line internal/php8/scanner.rl:327
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_COALESCE_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr330:
-		// line internal/php8/scanner.rl:356
+		goto st133
+	tr334:
+		// line internal/php8/scanner.rl:367
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4719,13 +4785,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_STRING
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr336:
-		// line internal/php8/scanner.rl:203
+		goto st133
+	tr340:
+		// line internal/php8/scanner.rl:214
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4733,13 +4799,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_NAME_QUALIFIED
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr412:
-		// line internal/php8/scanner.rl:222
+		goto st133
+	tr416:
+		// line internal/php8/scanner.rl:233
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4747,13 +4813,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_ELSE
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr432:
-		// line internal/php8/scanner.rl:226
+		goto st133
+	tr436:
+		// line internal/php8/scanner.rl:237
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4761,13 +4827,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_ENDFOR
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr461:
-		// line internal/php8/scanner.rl:234
+		goto st133
+	tr465:
+		// line internal/php8/scanner.rl:245
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4775,13 +4841,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_FINAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr465:
-		// line internal/php8/scanner.rl:236
+		goto st133
+	tr469:
+		// line internal/php8/scanner.rl:247
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4789,13 +4855,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_FOR
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr497:
-		// line internal/php8/scanner.rl:268
+		goto st133
+	tr501:
+		// line internal/php8/scanner.rl:279
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4803,13 +4869,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_INCLUDE
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr540:
-		// line internal/php8/scanner.rl:249
+		goto st133
+	tr544:
+		// line internal/php8/scanner.rl:260
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4817,13 +4883,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_NAMESPACE
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr542:
-		// line internal/php8/scanner.rl:202
+		goto st133
+	tr546:
+		// line internal/php8/scanner.rl:213
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4831,13 +4897,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_NAME_RELATIVE
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr578:
-		// line internal/php8/scanner.rl:270
+		goto st133
+	tr582:
+		// line internal/php8/scanner.rl:281
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4845,13 +4911,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_REQUIRE
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr624:
-		// line internal/php8/scanner.rl:267
+		goto st133
+	tr628:
+		// line internal/php8/scanner.rl:278
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4859,13 +4925,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_YIELD
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr625:
-		// line internal/php8/scanner.rl:205
+		goto st133
+	tr629:
+		// line internal/php8/scanner.rl:216
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4873,13 +4939,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_NS_SEPARATOR
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr626:
-		// line internal/php8/scanner.rl:204
+		goto st133
+	tr630:
+		// line internal/php8/scanner.rl:215
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -4887,271 +4953,271 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_NAME_FULLY_QUALIFIED
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr628:
-		// line internal/php8/scanner.rl:298
+		goto st133
+	tr632:
+		// line internal/php8/scanner.rl:309
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_XOR_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr702:
-		// line internal/php8/scanner.rl:291
+		goto st133
+	tr706:
+		// line internal/php8/scanner.rl:302
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_OR_EQUAL
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	tr703:
-		// line internal/php8/scanner.rl:289
+		goto st133
+	tr707:
+		// line internal/php8/scanner.rl:300
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_BOOLEAN_OR
 			{
 				(lex.p)++
-				lex.cs = 131
+				lex.cs = 133
 				goto _out
 			}
 		}
-		goto st131
-	st131:
+		goto st133
+	st133:
 		// line NONE:1
 		lex.ts = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof131
+			goto _test_eof133
 		}
-	st_case_131:
+	st_case_133:
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:3675
+		// line internal/php8/scanner.go:3718
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr11
 		case 13:
-			goto tr202
-		case 32:
-			goto tr201
-		case 33:
-			goto st135
-		case 34:
 			goto tr204
+		case 32:
+			goto tr203
+		case 33:
+			goto st137
+		case 34:
+			goto tr206
 		case 35:
-			goto st138
+			goto st140
 		case 36:
-			goto st141
-		case 37:
 			goto st143
+		case 37:
+			goto st145
 		case 38:
-			goto st144
+			goto st146
 		case 39:
-			goto tr209
+			goto tr211
 		case 40:
-			goto tr210
+			goto tr212
 		case 42:
-			goto st147
-		case 43:
 			goto st149
+		case 43:
+			goto st151
 		case 45:
-			goto st150
+			goto st152
 		case 46:
-			goto tr215
-		case 47:
-			goto tr216
-		case 48:
 			goto tr217
-		case 58:
-			goto st160
-		case 59:
+		case 47:
+			goto tr218
+		case 48:
 			goto tr219
+		case 58:
+			goto st163
+		case 59:
+			goto tr221
 		case 60:
-			goto st164
+			goto st167
 		case 61:
-			goto st168
+			goto st171
 		case 62:
-			goto st170
+			goto st173
 		case 63:
-			goto tr223
+			goto tr225
 		case 64:
-			goto tr211
+			goto tr213
 		case 65:
-			goto tr224
+			goto tr226
 		case 66:
-			goto tr225
+			goto tr227
 		case 67:
-			goto tr226
+			goto tr228
 		case 68:
-			goto tr227
+			goto tr229
 		case 69:
-			goto tr228
+			goto tr230
 		case 70:
-			goto tr229
+			goto tr231
 		case 71:
-			goto tr230
+			goto tr232
 		case 73:
-			goto tr232
+			goto tr234
 		case 76:
-			goto tr233
+			goto tr235
 		case 77:
-			goto tr234
+			goto tr236
 		case 78:
-			goto tr235
+			goto tr237
 		case 79:
-			goto tr236
+			goto tr238
 		case 80:
-			goto tr237
+			goto tr239
 		case 82:
-			goto tr238
+			goto tr240
 		case 83:
-			goto tr239
+			goto tr241
 		case 84:
-			goto tr240
+			goto tr242
 		case 85:
-			goto tr241
+			goto tr243
 		case 86:
-			goto tr242
+			goto tr244
 		case 87:
-			goto tr243
+			goto tr245
 		case 88:
-			goto tr244
+			goto tr246
 		case 89:
-			goto tr245
+			goto tr247
 		case 92:
-			goto st421
+			goto st424
 		case 94:
-			goto st423
+			goto st426
 		case 95:
-			goto tr248
-		case 96:
-			goto tr249
-		case 97:
-			goto tr224
-		case 98:
-			goto tr225
-		case 99:
-			goto tr226
-		case 100:
-			goto tr227
-		case 101:
-			goto tr228
-		case 102:
-			goto tr229
-		case 103:
-			goto tr230
-		case 105:
-			goto tr232
-		case 108:
-			goto tr233
-		case 109:
-			goto tr234
-		case 110:
-			goto tr235
-		case 111:
-			goto tr236
-		case 112:
-			goto tr237
-		case 114:
-			goto tr238
-		case 115:
-			goto tr239
-		case 116:
-			goto tr240
-		case 117:
-			goto tr241
-		case 118:
-			goto tr242
-		case 119:
-			goto tr243
-		case 120:
-			goto tr244
-		case 121:
-			goto tr245
-		case 123:
 			goto tr250
-		case 124:
-			goto st489
-		case 125:
+		case 96:
+			goto tr251
+		case 97:
+			goto tr226
+		case 98:
+			goto tr227
+		case 99:
+			goto tr228
+		case 100:
+			goto tr229
+		case 101:
+			goto tr230
+		case 102:
+			goto tr231
+		case 103:
+			goto tr232
+		case 105:
+			goto tr234
+		case 108:
+			goto tr235
+		case 109:
+			goto tr236
+		case 110:
+			goto tr237
+		case 111:
+			goto tr238
+		case 112:
+			goto tr239
+		case 114:
+			goto tr240
+		case 115:
+			goto tr241
+		case 116:
+			goto tr242
+		case 117:
+			goto tr243
+		case 118:
+			goto tr244
+		case 119:
+			goto tr245
+		case 120:
+			goto tr246
+		case 121:
+			goto tr247
+		case 123:
 			goto tr252
+		case 124:
+			goto st492
+		case 125:
+			goto tr254
 		case 126:
-			goto tr211
+			goto tr213
 		case 127:
-			goto tr200
+			goto tr202
 		}
 		switch {
 		case lex.data[(lex.p)] < 14:
 			switch {
 			case lex.data[(lex.p)] > 8:
 				if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-					goto tr201
+					goto tr203
 				}
 			default:
-				goto tr200
+				goto tr202
 			}
 		case lex.data[(lex.p)] > 31:
 			switch {
 			case lex.data[(lex.p)] < 49:
 				if 41 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 44 {
-					goto tr211
+					goto tr213
 				}
 			case lex.data[(lex.p)] > 57:
 				if 91 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 93 {
-					goto tr211
+					goto tr213
 				}
 			default:
 				goto tr102
 			}
 		default:
-			goto tr200
+			goto tr202
 		}
-		goto tr231
-	tr201:
+		goto tr233
+	tr203:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		goto st132
-	tr256:
+		goto st134
+	tr258:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
 		// line internal/php8/scanner.rl:54
 
-		goto st132
-	st132:
+		goto st134
+	st134:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof132
+			goto _test_eof134
 		}
-	st_case_132:
-		// line internal/php8/scanner.go:3872
+	st_case_134:
+		// line internal/php8/scanner.go:3915
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr11
 		case 13:
-			goto tr254
+			goto tr256
 		case 32:
-			goto tr201
+			goto tr203
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr201
+			goto tr203
 		}
-		goto tr253
+		goto tr255
 	tr11:
 		// line NONE:1
 		lex.te = (lex.p) + 1
@@ -5166,8 +5232,8 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st133
-	tr257:
+		goto st135
+	tr259:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -5183,26 +5249,26 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st133
-	st133:
+		goto st135
+	st135:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof133
+			goto _test_eof135
 		}
-	st_case_133:
-		// line internal/php8/scanner.go:3922
+	st_case_135:
+		// line internal/php8/scanner.go:3965
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr257
+			goto tr259
 		case 13:
-			goto tr258
+			goto tr260
 		case 32:
-			goto tr256
+			goto tr258
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr256
+			goto tr258
 		}
-		goto tr255
-	tr254:
+		goto tr257
+	tr256:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -5214,7 +5280,7 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 
 		goto st6
-	tr258:
+	tr260:
 		// line internal/php8/scanner.rl:54
 
 		// line internal/php8/scanner.rl:38
@@ -5233,12 +5299,12 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof6
 		}
 	st_case_6:
-		// line internal/php8/scanner.go:3966
+		// line internal/php8/scanner.go:4009
 		if lex.data[(lex.p)] == 10 {
 			goto tr11
 		}
 		goto tr10
-	tr202:
+	tr204:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -5249,48 +5315,48 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st134
-	st134:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof134
-		}
-	st_case_134:
-		// line internal/php8/scanner.go:3988
-		if lex.data[(lex.p)] == 10 {
-			goto tr11
-		}
-		goto tr259
-	st135:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof135
-		}
-	st_case_135:
-		if lex.data[(lex.p)] == 61 {
-			goto st136
-		}
-		goto tr260
+		goto st136
 	st136:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof136
 		}
 	st_case_136:
-		if lex.data[(lex.p)] == 61 {
-			goto tr263
+		// line internal/php8/scanner.go:4031
+		if lex.data[(lex.p)] == 10 {
+			goto tr11
 		}
-		goto tr262
-	tr204:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:382
-		lex.act = 149
-		goto st137
+		goto tr261
 	st137:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof137
 		}
 	st_case_137:
-		// line internal/php8/scanner.go:4023
+		if lex.data[(lex.p)] == 61 {
+			goto st138
+		}
+		goto tr262
+	st138:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof138
+		}
+	st_case_138:
+		if lex.data[(lex.p)] == 61 {
+			goto tr265
+		}
+		goto tr264
+	tr206:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:393
+		lex.act = 150
+		goto st139
+	st139:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof139
+		}
+	st_case_139:
+		// line internal/php8/scanner.go:4066
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr14
@@ -5323,7 +5389,7 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof7
 		}
 	st_case_7:
-		// line internal/php8/scanner.go:4056
+		// line internal/php8/scanner.go:4099
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr14
@@ -5401,131 +5467,51 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st9
 		}
 		goto st7
-	st138:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof138
-		}
-	st_case_138:
-		if lex.data[(lex.p)] == 91 {
-			goto tr267
-		}
-		goto st139
-	tr270:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st139
-	tr272:
-		// line internal/php8/scanner.rl:54
-
-		goto st139
-	tr274:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st139
-	st139:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof139
-		}
-	st_case_139:
-		// line internal/php8/scanner.go:4178
-		_widec = int16(lex.data[(lex.p)])
-		switch {
-		case lex.data[(lex.p)] < 11:
-			switch {
-			case lex.data[(lex.p)] > 9:
-				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
-					_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
-						_widec += 256
-					}
-				}
-			default:
-				_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
-					_widec += 256
-				}
-			}
-		case lex.data[(lex.p)] > 12:
-			switch {
-			case lex.data[(lex.p)] > 13:
-				if 14 <= lex.data[(lex.p)] {
-					_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
-						_widec += 256
-					}
-				}
-			case lex.data[(lex.p)] >= 13:
-				_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
-					_widec += 256
-				}
-			}
-		default:
-			_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
-			if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
-				_widec += 256
-			}
-		}
-		switch _widec {
-		case 522:
-			goto tr269
-		case 525:
-			goto tr270
-		}
-		if 512 <= _widec && _widec <= 767 {
-			goto st139
-		}
-		goto tr268
-	tr269:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st140
-	tr273:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st140
 	st140:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof140
 		}
 	st_case_140:
-		// line internal/php8/scanner.go:4258
+		if lex.data[(lex.p)] == 91 {
+			goto tr269
+		}
+		goto st141
+	tr272:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st141
+	tr274:
+		// line internal/php8/scanner.rl:54
+
+		goto st141
+	tr276:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st141
+	st141:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof141
+		}
+	st_case_141:
+		// line internal/php8/scanner.go:4221
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -5566,93 +5552,173 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 522:
-			goto tr273
+			goto tr271
 		case 525:
-			goto tr274
-		}
-		if 512 <= _widec && _widec <= 767 {
 			goto tr272
 		}
-		goto tr271
-	st141:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof141
+		if 512 <= _widec && _widec <= 767 {
+			goto st141
 		}
-	st_case_141:
-		if lex.data[(lex.p)] == 96 {
-			goto tr260
+		goto tr270
+	tr271:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
 		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr260
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr260
-			}
-		default:
-			goto tr260
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
 		}
+
+		goto st142
+	tr275:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
 		goto st142
 	st142:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof142
 		}
 	st_case_142:
-		if lex.data[(lex.p)] == 96 {
-			goto tr276
-		}
+		// line internal/php8/scanner.go:4301
+		_widec = int16(lex.data[(lex.p)])
 		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr276
-			}
-		case lex.data[(lex.p)] > 64:
+		case lex.data[(lex.p)] < 11:
 			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr276
+			case lex.data[(lex.p)] > 9:
+				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
+					_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
+						_widec += 256
+					}
 				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr276
+			default:
+				_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
+					_widec += 256
+				}
+			}
+		case lex.data[(lex.p)] > 12:
+			switch {
+			case lex.data[(lex.p)] > 13:
+				if 14 <= lex.data[(lex.p)] {
+					_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
+						_widec += 256
+					}
+				}
+			case lex.data[(lex.p)] >= 13:
+				_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
+					_widec += 256
+				}
 			}
 		default:
+			_widec = 256 + (int16(lex.data[(lex.p)]) - 0)
+			if lex.isNotPhpCloseToken() && lex.isNotNewLine() {
+				_widec += 256
+			}
+		}
+		switch _widec {
+		case 522:
+			goto tr275
+		case 525:
 			goto tr276
 		}
-		goto st142
+		if 512 <= _widec && _widec <= 767 {
+			goto tr274
+		}
+		goto tr273
 	st143:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof143
 		}
 	st_case_143:
-		if lex.data[(lex.p)] == 61 {
-			goto tr277
+		if lex.data[(lex.p)] == 96 {
+			goto tr262
 		}
-		goto tr260
+		switch {
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr262
+			}
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr262
+			}
+		default:
+			goto tr262
+		}
+		goto st144
 	st144:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof144
 		}
 	st_case_144:
-		switch lex.data[(lex.p)] {
-		case 38:
+		if lex.data[(lex.p)] == 96 {
 			goto tr278
-		case 61:
-			goto tr279
 		}
-		goto tr260
-	tr209:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st145
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr278
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr278
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr278
+			}
+		default:
+			goto tr278
+		}
+		goto st144
 	st145:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof145
 		}
 	st_case_145:
-		// line internal/php8/scanner.go:4385
+		if lex.data[(lex.p)] == 61 {
+			goto tr279
+		}
+		goto tr262
+	st146:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof146
+		}
+	st_case_146:
+		switch lex.data[(lex.p)] {
+		case 38:
+			goto tr280
+		case 61:
+			goto tr281
+		}
+		goto tr262
+	tr211:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st147
+	st147:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof147
+		}
+	st_case_147:
+		// line internal/php8/scanner.go:4428
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr21
@@ -5681,7 +5747,7 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof11
 		}
 	st_case_11:
-		// line internal/php8/scanner.go:4414
+		// line internal/php8/scanner.go:4457
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr21
@@ -5705,17 +5771,17 @@ func (lex *Lexer) Lex() *token.Token {
 			goto tr21
 		}
 		goto st11
-	tr210:
+	tr212:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		goto st146
-	st146:
+		goto st148
+	st148:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof146
+			goto _test_eof148
 		}
-	st_case_146:
-		// line internal/php8/scanner.go:4448
+	st_case_148:
+		// line internal/php8/scanner.go:4491
 		switch lex.data[(lex.p)] {
 		case 9:
 			goto st13
@@ -5761,7 +5827,7 @@ func (lex *Lexer) Lex() *token.Token {
 		if 11 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
 			goto st13
 		}
-		goto tr260
+		goto tr262
 	st13:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof13
@@ -6523,74 +6589,74 @@ func (lex *Lexer) Lex() *token.Token {
 			goto st67
 		}
 		goto tr23
-	st147:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof147
-		}
-	st_case_147:
-		switch lex.data[(lex.p)] {
-		case 42:
-			goto st148
-		case 61:
-			goto tr281
-		}
-		goto tr260
-	st148:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof148
-		}
-	st_case_148:
-		if lex.data[(lex.p)] == 61 {
-			goto tr283
-		}
-		goto tr282
 	st149:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof149
 		}
 	st_case_149:
 		switch lex.data[(lex.p)] {
-		case 43:
-			goto tr284
+		case 42:
+			goto st150
 		case 61:
-			goto tr285
+			goto tr283
 		}
-		goto tr260
+		goto tr262
 	st150:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof150
 		}
 	st_case_150:
-		switch lex.data[(lex.p)] {
-		case 45:
-			goto tr286
-		case 61:
-			goto tr287
-		case 62:
-			goto tr288
+		if lex.data[(lex.p)] == 61 {
+			goto tr285
 		}
-		goto tr260
-	tr215:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st151
+		goto tr284
 	st151:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof151
 		}
 	st_case_151:
-		// line internal/php8/scanner.go:5313
+		switch lex.data[(lex.p)] {
+		case 43:
+			goto tr286
+		case 61:
+			goto tr287
+		}
+		goto tr262
+	st152:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof152
+		}
+	st_case_152:
+		switch lex.data[(lex.p)] {
+		case 45:
+			goto tr288
+		case 61:
+			goto tr289
+		case 62:
+			goto tr290
+		}
+		goto tr262
+	tr217:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st153
+	st153:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof153
+		}
+	st_case_153:
+		// line internal/php8/scanner.go:5356
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st68
 		case 61:
-			goto tr290
+			goto tr292
 		}
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr91
 		}
-		goto tr260
+		goto tr262
 	st68:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof68
@@ -6604,15 +6670,15 @@ func (lex *Lexer) Lex() *token.Token {
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:165
+		// line internal/php8/scanner.rl:166
 		lex.act = 10
-		goto st152
-	st152:
+		goto st154
+	st154:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof152
+			goto _test_eof154
 		}
-	st_case_152:
-		// line internal/php8/scanner.go:5345
+	st_case_154:
+		// line internal/php8/scanner.go:5388
 		switch lex.data[(lex.p)] {
 		case 69:
 			goto st69
@@ -6624,7 +6690,7 @@ func (lex *Lexer) Lex() *token.Token {
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr91
 		}
-		goto tr291
+		goto tr293
 	st69:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof69
@@ -6653,22 +6719,22 @@ func (lex *Lexer) Lex() *token.Token {
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:165
+		// line internal/php8/scanner.rl:166
 		lex.act = 10
-		goto st153
-	st153:
+		goto st155
+	st155:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof153
+			goto _test_eof155
 		}
-	st_case_153:
-		// line internal/php8/scanner.go:5394
+	st_case_155:
+		// line internal/php8/scanner.go:5437
 		if lex.data[(lex.p)] == 95 {
 			goto st70
 		}
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr89
 		}
-		goto tr291
+		goto tr293
 	st71:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof71
@@ -6678,26 +6744,26 @@ func (lex *Lexer) Lex() *token.Token {
 			goto tr91
 		}
 		goto tr90
-	tr216:
+	tr218:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		goto st154
-	st154:
+		goto st156
+	st156:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof154
+			goto _test_eof156
 		}
-	st_case_154:
-		// line internal/php8/scanner.go:5421
+	st_case_156:
+		// line internal/php8/scanner.go:5464
 		switch lex.data[(lex.p)] {
 		case 42:
 			goto st72
 		case 47:
-			goto st139
+			goto st141
 		case 61:
-			goto tr294
+			goto tr296
 		}
-		goto tr260
+		goto tr262
 	tr94:
 		// line internal/php8/scanner.rl:38
 
@@ -6733,7 +6799,7 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof72
 		}
 	st_case_72:
-		// line internal/php8/scanner.go:5466
+		// line internal/php8/scanner.go:5509
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr93
@@ -6774,7 +6840,7 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof73
 		}
 	st_case_73:
-		// line internal/php8/scanner.go:5507
+		// line internal/php8/scanner.go:5550
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr97
@@ -6793,7 +6859,7 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof74
 		}
 	st_case_74:
-		// line internal/php8/scanner.go:5526
+		// line internal/php8/scanner.go:5569
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr93
@@ -6805,50 +6871,58 @@ func (lex *Lexer) Lex() *token.Token {
 			goto tr100
 		}
 		goto st72
-	tr217:
+	tr219:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:176
+		// line internal/php8/scanner.rl:177
 		lex.act = 12
-		goto st155
-	st155:
+		goto st157
+	st157:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof155
+			goto _test_eof157
 		}
-	st_case_155:
-		// line internal/php8/scanner.go:5550
+	st_case_157:
+		// line internal/php8/scanner.go:5593
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto tr296
+			goto tr298
+		case 66:
+			goto st76
 		case 69:
 			goto st69
+		case 79:
+			goto st77
+		case 88:
+			goto st78
 		case 95:
 			goto st75
 		case 98:
 			goto st76
 		case 101:
 			goto st69
-		case 120:
+		case 111:
 			goto st77
+		case 120:
+			goto st78
 		}
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr102
 		}
-		goto tr295
-	tr296:
+		goto tr297
+	tr298:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:165
+		// line internal/php8/scanner.rl:166
 		lex.act = 10
-		goto st156
-	st156:
+		goto st158
+	st158:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof156
+			goto _test_eof158
 		}
-	st_case_156:
-		// line internal/php8/scanner.go:5581
+	st_case_158:
+		// line internal/php8/scanner.go:5632
 		switch lex.data[(lex.p)] {
 		case 69:
 			goto st69
@@ -6858,23 +6932,23 @@ func (lex *Lexer) Lex() *token.Token {
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr91
 		}
-		goto tr291
+		goto tr293
 	tr102:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:176
+		// line internal/php8/scanner.rl:177
 		lex.act = 12
-		goto st157
-	st157:
+		goto st159
+	st159:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof157
+			goto _test_eof159
 		}
-	st_case_157:
-		// line internal/php8/scanner.go:5604
+	st_case_159:
+		// line internal/php8/scanner.go:5655
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto tr296
+			goto tr298
 		case 69:
 			goto st69
 		case 95:
@@ -6885,7 +6959,7 @@ func (lex *Lexer) Lex() *token.Token {
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr102
 		}
-		goto tr295
+		goto tr297
 	st75:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof75
@@ -6908,37 +6982,28 @@ func (lex *Lexer) Lex() *token.Token {
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:166
+		// line internal/php8/scanner.rl:167
 		lex.act = 11
-		goto st158
-	st158:
+		goto st160
+	st160:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof158
+			goto _test_eof160
 		}
-	st_case_158:
-		// line internal/php8/scanner.go:5649
+	st_case_160:
+		// line internal/php8/scanner.go:5700
 		if lex.data[(lex.p)] == 95 {
 			goto st76
 		}
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 49 {
 			goto tr103
 		}
-		goto tr300
+		goto tr303
 	st77:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof77
 		}
 	st_case_77:
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr104
-			}
-		case lex.data[(lex.p)] > 70:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
-				goto tr104
-			}
-		default:
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 56 {
 			goto tr104
 		}
 		goto tr12
@@ -6946,113 +7011,105 @@ func (lex *Lexer) Lex() *token.Token {
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:191
-		lex.act = 13
-		goto st159
-	st159:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof159
-		}
-	st_case_159:
-		// line internal/php8/scanner.go:5687
-		if lex.data[(lex.p)] == 95 {
-			goto st77
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr104
-			}
-		case lex.data[(lex.p)] > 70:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
-				goto tr104
-			}
-		default:
-			goto tr104
-		}
-		goto tr301
-	st160:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof160
-		}
-	st_case_160:
-		if lex.data[(lex.p)] == 58 {
-			goto tr302
-		}
-		goto tr260
-	tr219:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
+		// line internal/php8/scanner.rl:202
+		lex.act = 14
 		goto st161
 	st161:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof161
 		}
 	st_case_161:
-		// line internal/php8/scanner.go:5723
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr106
-		case 13:
-			goto tr107
-		case 32:
-			goto st78
-		case 63:
-			goto st81
+		// line internal/php8/scanner.go:5729
+		if lex.data[(lex.p)] == 95 {
+			goto st77
 		}
-		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto st78
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 56 {
+			goto tr104
 		}
-		goto tr260
-	tr109:
-		// line internal/php8/scanner.rl:54
-
-		goto st78
+		goto tr304
 	st78:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof78
 		}
 	st_case_78:
-		// line internal/php8/scanner.go:5747
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr105
+			}
+		case lex.data[(lex.p)] > 70:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
+				goto tr105
+			}
+		default:
+			goto tr105
+		}
+		goto tr12
+	tr105:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:192
+		lex.act = 13
+		goto st162
+	st162:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof162
+		}
+	st_case_162:
+		// line internal/php8/scanner.go:5767
+		if lex.data[(lex.p)] == 95 {
+			goto st78
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr105
+			}
+		case lex.data[(lex.p)] > 70:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
+				goto tr105
+			}
+		default:
+			goto tr105
+		}
+		goto tr305
+	st163:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof163
+		}
+	st_case_163:
+		if lex.data[(lex.p)] == 58 {
+			goto tr306
+		}
+		goto tr262
+	tr221:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st164
+	st164:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof164
+		}
+	st_case_164:
+		// line internal/php8/scanner.go:5803
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr106
-		case 13:
 			goto tr107
+		case 13:
+			goto tr108
 		case 32:
-			goto st78
+			goto st79
 		case 63:
-			goto st81
+			goto st82
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto st78
+			goto st79
 		}
-		goto tr23
-	tr106:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st79
+		goto tr262
 	tr110:
 		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
 
 		goto st79
 	st79:
@@ -7060,19 +7117,19 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof79
 		}
 	st_case_79:
-		// line internal/php8/scanner.go:5793
+		// line internal/php8/scanner.go:5827
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr110
+			goto tr107
 		case 13:
-			goto tr111
+			goto tr108
 		case 32:
-			goto tr109
+			goto st79
 		case 63:
-			goto tr112
+			goto st82
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr109
+			goto st79
 		}
 		goto tr23
 	tr107:
@@ -7106,13 +7163,45 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof80
 		}
 	st_case_80:
-		// line internal/php8/scanner.go:5839
-		if lex.data[(lex.p)] == 10 {
-			goto tr106
+		// line internal/php8/scanner.go:5873
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr111
+		case 13:
+			goto tr112
+		case 32:
+			goto tr110
+		case 63:
+			goto tr113
+		}
+		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
+			goto tr110
 		}
 		goto tr23
+	tr108:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st81
 	tr112:
 		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
 
 		goto st81
 	st81:
@@ -7120,58 +7209,13 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof81
 		}
 	st_case_81:
-		// line internal/php8/scanner.go:5853
-		if lex.data[(lex.p)] == 62 {
-			goto tr113
+		// line internal/php8/scanner.go:5919
+		if lex.data[(lex.p)] == 10 {
+			goto tr107
 		}
 		goto tr23
 	tr113:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st162
-	st162:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof162
-		}
-	st_case_162:
-		// line internal/php8/scanner.go:5868
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr115
-		case 13:
-			goto tr304
-		}
-		goto tr303
-	tr115:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st163
-	st163:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof163
-		}
-	st_case_163:
-		// line internal/php8/scanner.go:5893
-		goto tr305
-	tr304:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
+		// line internal/php8/scanner.rl:54
 
 		goto st82
 	st82:
@@ -7179,162 +7223,30 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof82
 		}
 	st_case_82:
-		// line internal/php8/scanner.go:5912
-		if lex.data[(lex.p)] == 10 {
-			goto tr115
+		// line internal/php8/scanner.go:5933
+		if lex.data[(lex.p)] == 62 {
+			goto tr114
 		}
-		goto tr114
-	st164:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof164
-		}
-	st_case_164:
-		switch lex.data[(lex.p)] {
-		case 60:
-			goto tr306
-		case 61:
-			goto st167
-		case 62:
-			goto tr308
-		}
-		goto tr260
-	tr306:
+		goto tr23
+	tr114:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:313
-		lex.act = 124
 		goto st165
 	st165:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof165
 		}
 	st_case_165:
-		// line internal/php8/scanner.go:5943
-		switch lex.data[(lex.p)] {
-		case 60:
-			goto st83
-		case 61:
-			goto tr310
-		}
-		goto tr309
-	st83:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof83
-		}
-	st_case_83:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st83
-		case 32:
-			goto st83
-		case 34:
-			goto st84
-		case 39:
-			goto st88
-		case 96:
-			goto tr12
-		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr12
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr12
-			}
-		default:
-			goto tr12
-		}
-		goto tr119
-	st84:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof84
-		}
-	st_case_84:
-		if lex.data[(lex.p)] == 96 {
-			goto tr12
-		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr12
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr12
-			}
-		default:
-			goto tr12
-		}
-		goto tr120
-	tr120:
-		// line internal/php8/scanner.rl:35
-		lblStart = lex.p
-		goto st85
-	st85:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof85
-		}
-	st_case_85:
-		// line internal/php8/scanner.go:6011
-		switch lex.data[(lex.p)] {
-		case 34:
-			goto tr121
-		case 96:
-			goto tr12
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr12
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr12
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr12
-			}
-		default:
-			goto tr12
-		}
-		goto st85
-	tr121:
-		// line internal/php8/scanner.rl:36
-		lblEnd = lex.p
-		goto st86
-	st86:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof86
-		}
-	st_case_86:
-		// line internal/php8/scanner.go:6045
+		// line internal/php8/scanner.go:5948
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr123
+			goto tr116
 		case 13:
-			goto tr124
+			goto tr308
 		}
-		goto tr12
-	tr123:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st166
-	tr127:
-		// line internal/php8/scanner.rl:36
-		lblEnd = lex.p
+		goto tr307
+	tr116:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -7351,8 +7263,166 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof166
 		}
 	st_case_166:
-		// line internal/php8/scanner.go:6084
-		goto tr311
+		// line internal/php8/scanner.go:5973
+		goto tr309
+	tr308:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st83
+	st83:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof83
+		}
+	st_case_83:
+		// line internal/php8/scanner.go:5992
+		if lex.data[(lex.p)] == 10 {
+			goto tr116
+		}
+		goto tr115
+	st167:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof167
+		}
+	st_case_167:
+		switch lex.data[(lex.p)] {
+		case 60:
+			goto tr310
+		case 61:
+			goto st170
+		case 62:
+			goto tr312
+		}
+		goto tr262
+	tr310:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:324
+		lex.act = 125
+		goto st168
+	st168:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof168
+		}
+	st_case_168:
+		// line internal/php8/scanner.go:6023
+		switch lex.data[(lex.p)] {
+		case 60:
+			goto st84
+		case 61:
+			goto tr314
+		}
+		goto tr313
+	st84:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof84
+		}
+	st_case_84:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st84
+		case 32:
+			goto st84
+		case 34:
+			goto st85
+		case 39:
+			goto st89
+		case 96:
+			goto tr12
+		}
+		switch {
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr12
+			}
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr12
+			}
+		default:
+			goto tr12
+		}
+		goto tr120
+	st85:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof85
+		}
+	st_case_85:
+		if lex.data[(lex.p)] == 96 {
+			goto tr12
+		}
+		switch {
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr12
+			}
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr12
+			}
+		default:
+			goto tr12
+		}
+		goto tr121
+	tr121:
+		// line internal/php8/scanner.rl:35
+		lblStart = lex.p
+		goto st86
+	st86:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof86
+		}
+	st_case_86:
+		// line internal/php8/scanner.go:6091
+		switch lex.data[(lex.p)] {
+		case 34:
+			goto tr122
+		case 96:
+			goto tr12
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr12
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr12
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr12
+			}
+		default:
+			goto tr12
+		}
+		goto st86
+	tr122:
+		// line internal/php8/scanner.rl:36
+		lblEnd = lex.p
+		goto st87
+	st87:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof87
+		}
+	st_case_87:
+		// line internal/php8/scanner.go:6125
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr124
+		case 13:
+			goto tr125
+		}
+		goto tr12
 	tr124:
 		// line internal/php8/scanner.rl:38
 
@@ -7364,7 +7434,7 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st87
+		goto st169
 	tr128:
 		// line internal/php8/scanner.rl:36
 		lblEnd = lex.p
@@ -7378,22 +7448,55 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st87
-	st87:
+		goto st169
+	st169:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof87
+			goto _test_eof169
 		}
-	st_case_87:
-		// line internal/php8/scanner.go:6117
-		if lex.data[(lex.p)] == 10 {
-			goto tr123
+	st_case_169:
+		// line internal/php8/scanner.go:6164
+		goto tr315
+	tr125:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
 		}
-		goto tr12
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st88
+	tr129:
+		// line internal/php8/scanner.rl:36
+		lblEnd = lex.p
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st88
 	st88:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof88
 		}
 	st_case_88:
+		// line internal/php8/scanner.go:6197
+		if lex.data[(lex.p)] == 10 {
+			goto tr124
+		}
+		goto tr12
+	st89:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof89
+		}
+	st_case_89:
 		if lex.data[(lex.p)] == 96 {
 			goto tr12
 		}
@@ -7409,42 +7512,8 @@ func (lex *Lexer) Lex() *token.Token {
 		default:
 			goto tr12
 		}
-		goto tr125
-	tr125:
-		// line internal/php8/scanner.rl:35
-		lblStart = lex.p
-		goto st89
-	st89:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof89
-		}
-	st_case_89:
-		// line internal/php8/scanner.go:6152
-		switch lex.data[(lex.p)] {
-		case 39:
-			goto tr121
-		case 96:
-			goto tr12
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr12
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr12
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr12
-			}
-		default:
-			goto tr12
-		}
-		goto st89
-	tr119:
+		goto tr126
+	tr126:
 		// line internal/php8/scanner.rl:35
 		lblStart = lex.p
 		goto st90
@@ -7453,12 +7522,10 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof90
 		}
 	st_case_90:
-		// line internal/php8/scanner.go:6186
+		// line internal/php8/scanner.go:6232
 		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr127
-		case 13:
-			goto tr128
+		case 39:
+			goto tr122
 		case 96:
 			goto tr12
 		}
@@ -7480,706 +7547,21 @@ func (lex *Lexer) Lex() *token.Token {
 			goto tr12
 		}
 		goto st90
-	st167:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof167
-		}
-	st_case_167:
-		if lex.data[(lex.p)] == 62 {
-			goto tr313
-		}
-		goto tr312
-	st168:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof168
-		}
-	st_case_168:
-		switch lex.data[(lex.p)] {
-		case 61:
-			goto st169
-		case 62:
-			goto tr315
-		}
-		goto tr260
-	st169:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof169
-		}
-	st_case_169:
-		if lex.data[(lex.p)] == 61 {
-			goto tr317
-		}
-		goto tr316
-	st170:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof170
-		}
-	st_case_170:
-		switch lex.data[(lex.p)] {
-		case 61:
-			goto tr318
-		case 62:
-			goto st171
-		}
-		goto tr260
-	st171:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof171
-		}
-	st_case_171:
-		if lex.data[(lex.p)] == 61 {
-			goto tr321
-		}
-		goto tr320
-	tr223:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st172
-	st172:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof172
-		}
-	st_case_172:
-		// line internal/php8/scanner.go:6274
-		switch lex.data[(lex.p)] {
-		case 45:
-			goto st91
-		case 62:
-			goto tr323
-		case 63:
-			goto st175
-		}
-		goto tr260
+	tr120:
+		// line internal/php8/scanner.rl:35
+		lblStart = lex.p
+		goto st91
 	st91:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof91
 		}
 	st_case_91:
-		if lex.data[(lex.p)] == 62 {
-			goto tr130
-		}
-		goto tr23
-	tr323:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st173
-	st173:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof173
-		}
-	st_case_173:
-		// line internal/php8/scanner.go:6303
+		// line internal/php8/scanner.go:6266
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr132
+			goto tr128
 		case 13:
-			goto tr326
-		}
-		goto tr325
-	tr132:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st174
-	st174:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof174
-		}
-	st_case_174:
-		// line internal/php8/scanner.go:6328
-		goto tr327
-	tr326:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st92
-	st92:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof92
-		}
-	st_case_92:
-		// line internal/php8/scanner.go:6347
-		if lex.data[(lex.p)] == 10 {
-			goto tr132
-		}
-		goto tr131
-	st175:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof175
-		}
-	st_case_175:
-		if lex.data[(lex.p)] == 61 {
-			goto tr329
-		}
-		goto tr328
-	tr224:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st176
-	st176:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof176
-		}
-	st_case_176:
-		// line internal/php8/scanner.go:6373
-		switch lex.data[(lex.p)] {
-		case 66:
-			goto tr331
-		case 78:
-			goto tr332
-		case 82:
-			goto tr333
-		case 83:
-			goto tr334
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 98:
-			goto tr331
-		case 110:
-			goto tr332
-		case 114:
-			goto tr333
-		case 115:
-			goto tr334
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr231:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st177
-	tr334:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:209
-		lex.act = 20
-		goto st177
-	tr342:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:207
-		lex.act = 18
-		goto st177
-	tr343:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:282
-		lex.act = 93
-		goto st177
-	tr346:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:208
-		lex.act = 19
-		goto st177
-	tr351:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:210
-		lex.act = 21
-		goto st177
-	tr363:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:211
-		lex.act = 22
-		goto st177
-	tr364:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:212
-		lex.act = 23
-		goto st177
-	tr366:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:213
-		lex.act = 24
-		goto st177
-	tr373:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:238
-		lex.act = 49
-		goto st177
-	tr377:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:214
-		lex.act = 25
-		goto st177
-	tr379:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:215
-		lex.act = 26
-		goto st177
-	tr383:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:216
-		lex.act = 27
-		goto st177
-	tr387:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:217
-		lex.act = 28
-		goto st177
-	tr390:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:220
-		lex.act = 31
-		goto st177
-	tr396:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:218
-		lex.act = 29
-		goto st177
-	tr400:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:219
-		lex.act = 30
-		goto st177
-	tr401:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:232
-		lex.act = 43
-		goto st177
-	tr409:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:221
-		lex.act = 32
-		goto st177
-	tr414:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:223
-		lex.act = 34
-		goto st177
-	tr417:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:224
-		lex.act = 35
-		goto st177
-	tr429:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:225
-		lex.act = 36
-		goto st177
-	tr436:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:227
-		lex.act = 38
-		goto st177
-	tr437:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:228
-		lex.act = 39
-		goto st177
-	tr442:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:229
-		lex.act = 40
-		goto st177
-	tr446:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:230
-		lex.act = 41
-		goto st177
-	tr448:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:231
-		lex.act = 42
-		goto st177
-	tr454:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:233
-		lex.act = 44
-		goto st177
-	tr456:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:239
-		lex.act = 50
-		goto st177
-	tr463:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:235
-		lex.act = 46
-		goto st177
-	tr469:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:237
-		lex.act = 48
-		goto st177
-	tr475:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:240
-		lex.act = 51
-		goto st177
-	tr477:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:241
-		lex.act = 52
-		goto st177
-	tr478:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:242
-		lex.act = 53
-		goto st177
-	tr489:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:244
-		lex.act = 55
-		goto st177
-	tr502:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:269
-		lex.act = 80
-		goto st177
-	tr510:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:245
-		lex.act = 56
-		goto st177
-	tr514:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:246
-		lex.act = 57
-		goto st177
-	tr520:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:247
-		lex.act = 58
-		goto st177
-	tr523:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:243
-		lex.act = 54
-		goto st177
-	tr526:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:248
-		lex.act = 59
-		goto st177
-	tr530:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:258
-		lex.act = 69
-		goto st177
-	tr543:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:281
-		lex.act = 92
-		goto st177
-	tr544:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:283
-		lex.act = 94
-		goto st177
-	tr551:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:252
-		lex.act = 63
-		goto st177
-	tr554:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:250
-		lex.act = 61
-		goto st177
-	tr560:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:253
-		lex.act = 64
-		goto st177
-	tr564:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:251
-		lex.act = 62
-		goto st177
-	tr573:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:255
-		lex.act = 66
-		goto st177
-	tr583:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:271
-		lex.act = 82
-		goto st177
-	tr586:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:254
-		lex.act = 65
-		goto st177
-	tr592:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:256
-		lex.act = 67
-		goto st177
-	tr596:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:257
-		lex.act = 68
-		goto st177
-	tr601:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:259
-		lex.act = 70
-		goto st177
-	tr603:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:261
-		lex.act = 72
-		goto st177
-	tr605:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:260
-		lex.act = 71
-		goto st177
-	tr610:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:262
-		lex.act = 73
-		goto st177
-	tr611:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:263
-		lex.act = 74
-		goto st177
-	tr613:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:264
-		lex.act = 75
-		goto st177
-	tr617:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:265
-		lex.act = 76
-		goto st177
-	tr619:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:284
-		lex.act = 95
-		goto st177
-	tr643:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:272
-		lex.act = 83
-		goto st177
-	tr647:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:273
-		lex.act = 84
-		goto st177
-	tr653:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:274
-		lex.act = 85
-		goto st177
-	tr661:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:275
-		lex.act = 86
-		goto st177
-	tr673:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:280
-		lex.act = 91
-		goto st177
-	tr678:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:276
-		lex.act = 87
-		goto st177
-	tr685:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:278
-		lex.act = 89
-		goto st177
-	tr695:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:277
-		lex.act = 88
-		goto st177
-	tr701:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:279
-		lex.act = 90
-		goto st177
-	st177:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof177
-		}
-	st_case_177:
-		// line internal/php8/scanner.go:6909
-		switch lex.data[(lex.p)] {
-		case 92:
-			goto st93
+			goto tr129
 		case 96:
 			goto tr12
 		}
@@ -8200,12 +7582,733 @@ func (lex *Lexer) Lex() *token.Token {
 		default:
 			goto tr12
 		}
-		goto tr231
+		goto st91
+	st170:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof170
+		}
+	st_case_170:
+		if lex.data[(lex.p)] == 62 {
+			goto tr317
+		}
+		goto tr316
+	st171:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof171
+		}
+	st_case_171:
+		switch lex.data[(lex.p)] {
+		case 61:
+			goto st172
+		case 62:
+			goto tr319
+		}
+		goto tr262
+	st172:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof172
+		}
+	st_case_172:
+		if lex.data[(lex.p)] == 61 {
+			goto tr321
+		}
+		goto tr320
+	st173:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof173
+		}
+	st_case_173:
+		switch lex.data[(lex.p)] {
+		case 61:
+			goto tr322
+		case 62:
+			goto st174
+		}
+		goto tr262
+	st174:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof174
+		}
+	st_case_174:
+		if lex.data[(lex.p)] == 61 {
+			goto tr325
+		}
+		goto tr324
+	tr225:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st175
+	st175:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof175
+		}
+	st_case_175:
+		// line internal/php8/scanner.go:6354
+		switch lex.data[(lex.p)] {
+		case 45:
+			goto st92
+		case 62:
+			goto tr327
+		case 63:
+			goto st178
+		}
+		goto tr262
+	st92:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof92
+		}
+	st_case_92:
+		if lex.data[(lex.p)] == 62 {
+			goto tr131
+		}
+		goto tr23
+	tr327:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st176
+	st176:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof176
+		}
+	st_case_176:
+		// line internal/php8/scanner.go:6383
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr133
+		case 13:
+			goto tr330
+		}
+		goto tr329
+	tr133:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st177
+	st177:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof177
+		}
+	st_case_177:
+		// line internal/php8/scanner.go:6408
+		goto tr331
+	tr330:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st93
 	st93:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof93
 		}
 	st_case_93:
+		// line internal/php8/scanner.go:6427
+		if lex.data[(lex.p)] == 10 {
+			goto tr133
+		}
+		goto tr132
+	st178:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof178
+		}
+	st_case_178:
+		if lex.data[(lex.p)] == 61 {
+			goto tr333
+		}
+		goto tr332
+	tr226:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st179
+	st179:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof179
+		}
+	st_case_179:
+		// line internal/php8/scanner.go:6453
+		switch lex.data[(lex.p)] {
+		case 66:
+			goto tr335
+		case 78:
+			goto tr336
+		case 82:
+			goto tr337
+		case 83:
+			goto tr338
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 98:
+			goto tr335
+		case 110:
+			goto tr336
+		case 114:
+			goto tr337
+		case 115:
+			goto tr338
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr233:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st180
+	tr338:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:220
+		lex.act = 21
+		goto st180
+	tr346:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:218
+		lex.act = 19
+		goto st180
+	tr347:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:293
+		lex.act = 94
+		goto st180
+	tr350:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:219
+		lex.act = 20
+		goto st180
+	tr355:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:221
+		lex.act = 22
+		goto st180
+	tr367:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:222
+		lex.act = 23
+		goto st180
+	tr368:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:223
+		lex.act = 24
+		goto st180
+	tr370:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:224
+		lex.act = 25
+		goto st180
+	tr377:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:249
+		lex.act = 50
+		goto st180
+	tr381:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:225
+		lex.act = 26
+		goto st180
+	tr383:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:226
+		lex.act = 27
+		goto st180
+	tr387:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:227
+		lex.act = 28
+		goto st180
+	tr391:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:228
+		lex.act = 29
+		goto st180
+	tr394:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:231
+		lex.act = 32
+		goto st180
+	tr400:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:229
+		lex.act = 30
+		goto st180
+	tr404:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:230
+		lex.act = 31
+		goto st180
+	tr405:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:243
+		lex.act = 44
+		goto st180
+	tr413:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:232
+		lex.act = 33
+		goto st180
+	tr418:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:234
+		lex.act = 35
+		goto st180
+	tr421:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:235
+		lex.act = 36
+		goto st180
+	tr433:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:236
+		lex.act = 37
+		goto st180
+	tr440:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:238
+		lex.act = 39
+		goto st180
+	tr441:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:239
+		lex.act = 40
+		goto st180
+	tr446:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:240
+		lex.act = 41
+		goto st180
+	tr450:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:241
+		lex.act = 42
+		goto st180
+	tr452:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:242
+		lex.act = 43
+		goto st180
+	tr458:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:244
+		lex.act = 45
+		goto st180
+	tr460:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:250
+		lex.act = 51
+		goto st180
+	tr467:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:246
+		lex.act = 47
+		goto st180
+	tr473:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:248
+		lex.act = 49
+		goto st180
+	tr479:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:251
+		lex.act = 52
+		goto st180
+	tr481:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:252
+		lex.act = 53
+		goto st180
+	tr482:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:253
+		lex.act = 54
+		goto st180
+	tr493:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:255
+		lex.act = 56
+		goto st180
+	tr506:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:280
+		lex.act = 81
+		goto st180
+	tr514:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:256
+		lex.act = 57
+		goto st180
+	tr518:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:257
+		lex.act = 58
+		goto st180
+	tr524:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:258
+		lex.act = 59
+		goto st180
+	tr527:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:254
+		lex.act = 55
+		goto st180
+	tr530:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:259
+		lex.act = 60
+		goto st180
+	tr534:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:269
+		lex.act = 70
+		goto st180
+	tr547:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:292
+		lex.act = 93
+		goto st180
+	tr548:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:294
+		lex.act = 95
+		goto st180
+	tr555:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:263
+		lex.act = 64
+		goto st180
+	tr558:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:261
+		lex.act = 62
+		goto st180
+	tr564:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:264
+		lex.act = 65
+		goto st180
+	tr568:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:262
+		lex.act = 63
+		goto st180
+	tr577:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:266
+		lex.act = 67
+		goto st180
+	tr587:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:282
+		lex.act = 83
+		goto st180
+	tr590:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:265
+		lex.act = 66
+		goto st180
+	tr596:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:267
+		lex.act = 68
+		goto st180
+	tr600:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:268
+		lex.act = 69
+		goto st180
+	tr605:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:270
+		lex.act = 71
+		goto st180
+	tr607:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:272
+		lex.act = 73
+		goto st180
+	tr609:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:271
+		lex.act = 72
+		goto st180
+	tr614:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:273
+		lex.act = 74
+		goto st180
+	tr615:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:274
+		lex.act = 75
+		goto st180
+	tr617:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:275
+		lex.act = 76
+		goto st180
+	tr621:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:276
+		lex.act = 77
+		goto st180
+	tr623:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:295
+		lex.act = 96
+		goto st180
+	tr647:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:283
+		lex.act = 84
+		goto st180
+	tr651:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:284
+		lex.act = 85
+		goto st180
+	tr657:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:285
+		lex.act = 86
+		goto st180
+	tr665:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:286
+		lex.act = 87
+		goto st180
+	tr677:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:291
+		lex.act = 92
+		goto st180
+	tr682:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:287
+		lex.act = 88
+		goto st180
+	tr689:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:289
+		lex.act = 90
+		goto st180
+	tr699:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:288
+		lex.act = 89
+		goto st180
+	tr705:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:290
+		lex.act = 91
+		goto st180
+	st180:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof180
+		}
+	st_case_180:
+		// line internal/php8/scanner.go:6989
+		switch lex.data[(lex.p)] {
+		case 92:
+			goto st94
+		case 96:
+			goto tr12
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr12
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr12
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr12
+			}
+		default:
+			goto tr12
+		}
+		goto tr233
+	st94:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof94
+		}
+	st_case_94:
 		if lex.data[(lex.p)] == 96 {
 			goto tr12
 		}
@@ -8221,4402 +8324,4279 @@ func (lex *Lexer) Lex() *token.Token {
 		default:
 			goto tr12
 		}
-		goto tr133
-	tr133:
+		goto tr134
+	tr134:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:203
-		lex.act = 15
-		goto st178
-	st178:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof178
-		}
-	st_case_178:
-		// line internal/php8/scanner.go:6967
-		switch lex.data[(lex.p)] {
-		case 92:
-			goto st93
-		case 96:
-			goto tr336
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr336
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr336
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr336
-			}
-		default:
-			goto tr336
-		}
-		goto tr133
-	tr331:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st179
-	st179:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof179
-		}
-	st_case_179:
-		// line internal/php8/scanner.go:7004
-		switch lex.data[(lex.p)] {
-		case 83:
-			goto tr337
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 115:
-			goto tr337
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr337:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st180
-	st180:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof180
-		}
-	st_case_180:
-		// line internal/php8/scanner.go:7045
-		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr338
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 116:
-			goto tr338
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr338:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:214
+		lex.act = 16
 		goto st181
 	st181:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof181
 		}
 	st_case_181:
-		// line internal/php8/scanner.go:7086
+		// line internal/php8/scanner.go:7047
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr339
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr339
+			goto tr340
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr340
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr340
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr340
 			}
 		default:
-			goto tr330
+			goto tr340
 		}
-		goto tr231
-	tr339:
+		goto tr134
+	tr335:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st182
 	st182:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof182
 		}
 	st_case_182:
-		// line internal/php8/scanner.go:7127
+		// line internal/php8/scanner.go:7084
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr340
+		case 83:
+			goto tr341
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr340
+			goto tr334
+		case 115:
+			goto tr341
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr340:
+		goto tr233
+	tr341:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st183
 	st183:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof183
 		}
 	st_case_183:
-		// line internal/php8/scanner.go:7168
+		// line internal/php8/scanner.go:7125
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr341
+		case 84:
+			goto tr342
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr341
+			goto tr334
+		case 116:
+			goto tr342
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr341:
+		goto tr233
+	tr342:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st184
 	st184:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof184
 		}
 	st_case_184:
-		// line internal/php8/scanner.go:7209
+		// line internal/php8/scanner.go:7166
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr342
+		case 82:
+			goto tr343
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr342
+			goto tr334
+		case 114:
+			goto tr343
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr332:
+		goto tr233
+	tr343:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st185
 	st185:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof185
 		}
 	st_case_185:
-		// line internal/php8/scanner.go:7250
+		// line internal/php8/scanner.go:7207
 		switch lex.data[(lex.p)] {
-		case 68:
-			goto tr343
+		case 65:
+			goto tr344
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 100:
-			goto tr343
+			goto tr334
+		case 97:
+			goto tr344
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr333:
+		goto tr233
+	tr344:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st186
 	st186:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof186
 		}
 	st_case_186:
-		// line internal/php8/scanner.go:7291
+		// line internal/php8/scanner.go:7248
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr344
+		case 67:
+			goto tr345
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr344
+			goto tr334
+		case 99:
+			goto tr345
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr344:
+		goto tr233
+	tr345:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st187
 	st187:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof187
 		}
 	st_case_187:
-		// line internal/php8/scanner.go:7332
+		// line internal/php8/scanner.go:7289
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr345
+		case 84:
+			goto tr346
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr345
+			goto tr334
+		case 116:
+			goto tr346
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr345:
+		goto tr233
+	tr336:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st188
 	st188:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof188
 		}
 	st_case_188:
-		// line internal/php8/scanner.go:7373
+		// line internal/php8/scanner.go:7330
 		switch lex.data[(lex.p)] {
-		case 89:
-			goto tr346
+		case 68:
+			goto tr347
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 121:
-			goto tr346
+			goto tr334
+		case 100:
+			goto tr347
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr225:
+		goto tr233
+	tr337:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st189
 	st189:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof189
 		}
 	st_case_189:
-		// line internal/php8/scanner.go:7414
+		// line internal/php8/scanner.go:7371
 		switch lex.data[(lex.p)] {
-		case 34:
-			goto st7
-		case 60:
-			goto st94
 		case 82:
 			goto tr348
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 114:
 			goto tr348
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	st94:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof94
-		}
-	st_case_94:
-		if lex.data[(lex.p)] == 60 {
-			goto st95
-		}
-		goto tr134
-	st95:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof95
-		}
-	st_case_95:
-		if lex.data[(lex.p)] == 60 {
-			goto st83
-		}
-		goto tr134
+		goto tr233
 	tr348:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st190
 	st190:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof190
 		}
 	st_case_190:
-		// line internal/php8/scanner.go:7477
+		// line internal/php8/scanner.go:7412
 		switch lex.data[(lex.p)] {
-		case 69:
+		case 65:
 			goto tr349
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
+			goto tr334
+		case 97:
 			goto tr349
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr349:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st191
 	st191:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof191
 		}
 	st_case_191:
-		// line internal/php8/scanner.go:7518
+		// line internal/php8/scanner.go:7453
 		switch lex.data[(lex.p)] {
-		case 65:
+		case 89:
 			goto tr350
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
+			goto tr334
+		case 121:
 			goto tr350
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr350:
+		goto tr233
+	tr227:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st192
 	st192:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof192
 		}
 	st_case_192:
-		// line internal/php8/scanner.go:7559
+		// line internal/php8/scanner.go:7494
 		switch lex.data[(lex.p)] {
-		case 75:
-			goto tr351
+		case 34:
+			goto st7
+		case 60:
+			goto st95
+		case 82:
+			goto tr352
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 107:
-			goto tr351
+			goto tr334
+		case 114:
+			goto tr352
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr226:
+		goto tr233
+	st95:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof95
+		}
+	st_case_95:
+		if lex.data[(lex.p)] == 60 {
+			goto st96
+		}
+		goto tr135
+	st96:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof96
+		}
+	st_case_96:
+		if lex.data[(lex.p)] == 60 {
+			goto st84
+		}
+		goto tr135
+	tr352:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st193
 	st193:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof193
 		}
 	st_case_193:
-		// line internal/php8/scanner.go:7600
+		// line internal/php8/scanner.go:7557
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr352
-		case 70:
+		case 69:
 			goto tr353
-		case 76:
-			goto tr354
-		case 79:
-			goto tr355
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr352
-		case 102:
+			goto tr334
+		case 101:
 			goto tr353
-		case 108:
-			goto tr354
-		case 111:
-			goto tr355
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr352:
+		goto tr233
+	tr353:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st194
 	st194:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof194
 		}
 	st_case_194:
-		// line internal/php8/scanner.go:7653
+		// line internal/php8/scanner.go:7598
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr356
-		case 83:
-			goto tr357
-		case 84:
-			goto tr358
+		case 65:
+			goto tr354
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr356
-		case 115:
-			goto tr357
-		case 116:
-			goto tr358
+			goto tr334
+		case 97:
+			goto tr354
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr356:
+		goto tr233
+	tr354:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st195
 	st195:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof195
 		}
 	st_case_195:
-		// line internal/php8/scanner.go:7702
+		// line internal/php8/scanner.go:7639
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr359
+		case 75:
+			goto tr355
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr359
+			goto tr334
+		case 107:
+			goto tr355
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr359:
+		goto tr233
+	tr228:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st196
 	st196:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof196
 		}
 	st_case_196:
-		// line internal/php8/scanner.go:7743
+		// line internal/php8/scanner.go:7680
 		switch lex.data[(lex.p)] {
 		case 65:
-			goto tr360
+			goto tr356
+		case 70:
+			goto tr357
+		case 76:
+			goto tr358
+		case 79:
+			goto tr359
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 97:
-			goto tr360
+			goto tr356
+		case 102:
+			goto tr357
+		case 108:
+			goto tr358
+		case 111:
+			goto tr359
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr360:
+		goto tr233
+	tr356:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st197
 	st197:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof197
 		}
 	st_case_197:
-		// line internal/php8/scanner.go:7784
+		// line internal/php8/scanner.go:7733
 		switch lex.data[(lex.p)] {
-		case 66:
+		case 76:
+			goto tr360
+		case 83:
 			goto tr361
+		case 84:
+			goto tr362
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 98:
+			goto tr334
+		case 108:
+			goto tr360
+		case 115:
 			goto tr361
+		case 116:
+			goto tr362
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr361:
+		goto tr233
+	tr360:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st198
 	st198:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof198
 		}
 	st_case_198:
-		// line internal/php8/scanner.go:7825
+		// line internal/php8/scanner.go:7782
 		switch lex.data[(lex.p)] {
 		case 76:
-			goto tr362
+			goto tr363
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 108:
-			goto tr362
+			goto tr363
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr362:
+		goto tr233
+	tr363:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st199
 	st199:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof199
 		}
 	st_case_199:
-		// line internal/php8/scanner.go:7866
+		// line internal/php8/scanner.go:7823
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr363
+		case 65:
+			goto tr364
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr363
+			goto tr334
+		case 97:
+			goto tr364
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr357:
+		goto tr233
+	tr364:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st200
 	st200:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof200
 		}
 	st_case_200:
-		// line internal/php8/scanner.go:7907
+		// line internal/php8/scanner.go:7864
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr364
+		case 66:
+			goto tr365
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr364
+			goto tr334
+		case 98:
+			goto tr365
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr358:
+		goto tr233
+	tr365:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st201
 	st201:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof201
 		}
 	st_case_201:
-		// line internal/php8/scanner.go:7948
+		// line internal/php8/scanner.go:7905
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr365
+		case 76:
+			goto tr366
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr365
+			goto tr334
+		case 108:
+			goto tr366
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr365:
+		goto tr233
+	tr366:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st202
 	st202:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof202
 		}
 	st_case_202:
-		// line internal/php8/scanner.go:7989
+		// line internal/php8/scanner.go:7946
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr366
+		case 69:
+			goto tr367
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
-			goto tr366
+			goto tr334
+		case 101:
+			goto tr367
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr353:
+		goto tr233
+	tr361:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st203
 	st203:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof203
 		}
 	st_case_203:
-		// line internal/php8/scanner.go:8030
+		// line internal/php8/scanner.go:7987
 		switch lex.data[(lex.p)] {
-		case 85:
-			goto tr367
+		case 69:
+			goto tr368
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 117:
-			goto tr367
+			goto tr334
+		case 101:
+			goto tr368
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr367:
+		goto tr233
+	tr362:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st204
 	st204:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof204
 		}
 	st_case_204:
-		// line internal/php8/scanner.go:8071
+		// line internal/php8/scanner.go:8028
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr368
+		case 67:
+			goto tr369
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr368
+			goto tr334
+		case 99:
+			goto tr369
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr368:
+		goto tr233
+	tr369:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st205
 	st205:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof205
 		}
 	st_case_205:
-		// line internal/php8/scanner.go:8112
+		// line internal/php8/scanner.go:8069
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr369
+		case 72:
+			goto tr370
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr369
+			goto tr334
+		case 104:
+			goto tr370
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr369:
+		goto tr233
+	tr357:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st206
 	st206:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof206
 		}
 	st_case_206:
-		// line internal/php8/scanner.go:8153
+		// line internal/php8/scanner.go:8110
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr370
+		case 85:
+			goto tr371
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr370
+			goto tr334
+		case 117:
+			goto tr371
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr370:
+		goto tr233
+	tr371:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st207
 	st207:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof207
 		}
 	st_case_207:
-		// line internal/php8/scanner.go:8194
+		// line internal/php8/scanner.go:8151
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr371
+		case 78:
+			goto tr372
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr371
+			goto tr334
+		case 110:
+			goto tr372
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr371:
+		goto tr233
+	tr372:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st208
 	st208:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof208
 		}
 	st_case_208:
-		// line internal/php8/scanner.go:8235
+		// line internal/php8/scanner.go:8192
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr372
+		case 67:
+			goto tr373
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr372
+			goto tr334
+		case 99:
+			goto tr373
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr372:
+		goto tr233
+	tr373:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st209
 	st209:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof209
 		}
 	st_case_209:
-		// line internal/php8/scanner.go:8276
+		// line internal/php8/scanner.go:8233
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr373
+		case 84:
+			goto tr374
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr373
+			goto tr334
+		case 116:
+			goto tr374
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr354:
+		goto tr233
+	tr374:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st210
 	st210:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof210
 		}
 	st_case_210:
-		// line internal/php8/scanner.go:8317
+		// line internal/php8/scanner.go:8274
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr374
-		case 79:
+		case 73:
 			goto tr375
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr374
-		case 111:
+			goto tr334
+		case 105:
 			goto tr375
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr374:
+		goto tr233
+	tr375:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st211
 	st211:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof211
 		}
 	st_case_211:
-		// line internal/php8/scanner.go:8362
+		// line internal/php8/scanner.go:8315
 		switch lex.data[(lex.p)] {
-		case 83:
+		case 79:
 			goto tr376
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
+			goto tr334
+		case 111:
 			goto tr376
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr376:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st212
 	st212:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof212
 		}
 	st_case_212:
-		// line internal/php8/scanner.go:8403
+		// line internal/php8/scanner.go:8356
 		switch lex.data[(lex.p)] {
-		case 83:
+		case 78:
 			goto tr377
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
+			goto tr334
+		case 110:
 			goto tr377
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr375:
+		goto tr233
+	tr358:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st213
 	st213:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof213
 		}
 	st_case_213:
-		// line internal/php8/scanner.go:8444
+		// line internal/php8/scanner.go:8397
 		switch lex.data[(lex.p)] {
-		case 78:
+		case 65:
 			goto tr378
+		case 79:
+			goto tr379
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
+			goto tr334
+		case 97:
 			goto tr378
+		case 111:
+			goto tr379
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr378:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st214
 	st214:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof214
 		}
 	st_case_214:
-		// line internal/php8/scanner.go:8485
+		// line internal/php8/scanner.go:8442
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr379
+		case 83:
+			goto tr380
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr379
+			goto tr334
+		case 115:
+			goto tr380
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr355:
+		goto tr233
+	tr380:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st215
 	st215:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof215
 		}
 	st_case_215:
-		// line internal/php8/scanner.go:8526
+		// line internal/php8/scanner.go:8483
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr380
+		case 83:
+			goto tr381
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr380
+			goto tr334
+		case 115:
+			goto tr381
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr380:
+		goto tr233
+	tr379:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st216
 	st216:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof216
 		}
 	st_case_216:
-		// line internal/php8/scanner.go:8567
+		// line internal/php8/scanner.go:8524
 		switch lex.data[(lex.p)] {
-		case 83:
-			goto tr381
-		case 84:
+		case 78:
 			goto tr382
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
-			goto tr381
-		case 116:
+			goto tr334
+		case 110:
 			goto tr382
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr381:
+		goto tr233
+	tr382:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st217
 	st217:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof217
 		}
 	st_case_217:
-		// line internal/php8/scanner.go:8612
+		// line internal/php8/scanner.go:8565
 		switch lex.data[(lex.p)] {
-		case 84:
+		case 69:
 			goto tr383
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
+			goto tr334
+		case 101:
 			goto tr383
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr382:
+		goto tr233
+	tr359:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st218
 	st218:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof218
 		}
 	st_case_218:
-		// line internal/php8/scanner.go:8653
+		// line internal/php8/scanner.go:8606
 		switch lex.data[(lex.p)] {
-		case 73:
+		case 78:
 			goto tr384
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
+			goto tr334
+		case 110:
 			goto tr384
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr384:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st219
 	st219:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof219
 		}
 	st_case_219:
-		// line internal/php8/scanner.go:8694
+		// line internal/php8/scanner.go:8647
 		switch lex.data[(lex.p)] {
-		case 78:
+		case 83:
 			goto tr385
+		case 84:
+			goto tr386
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
+			goto tr334
+		case 115:
 			goto tr385
+		case 116:
+			goto tr386
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr385:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st220
 	st220:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof220
 		}
 	st_case_220:
-		// line internal/php8/scanner.go:8735
+		// line internal/php8/scanner.go:8692
 		switch lex.data[(lex.p)] {
-		case 85:
-			goto tr386
+		case 84:
+			goto tr387
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 117:
-			goto tr386
+			goto tr334
+		case 116:
+			goto tr387
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr386:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st221
 	st221:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof221
 		}
 	st_case_221:
-		// line internal/php8/scanner.go:8776
+		// line internal/php8/scanner.go:8733
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr387
+		case 73:
+			goto tr388
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr387
+			goto tr334
+		case 105:
+			goto tr388
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr227:
+		goto tr233
+	tr388:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st222
 	st222:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof222
 		}
 	st_case_222:
-		// line internal/php8/scanner.go:8817
+		// line internal/php8/scanner.go:8774
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr388
-		case 73:
+		case 78:
 			goto tr389
-		case 79:
-			goto tr390
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr388
-		case 105:
+			goto tr334
+		case 110:
 			goto tr389
-		case 111:
-			goto tr390
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr388:
+		goto tr233
+	tr389:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st223
 	st223:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof223
 		}
 	st_case_223:
-		// line internal/php8/scanner.go:8866
+		// line internal/php8/scanner.go:8815
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr391
-		case 70:
-			goto tr392
+		case 85:
+			goto tr390
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr391
-		case 102:
-			goto tr392
+			goto tr334
+		case 117:
+			goto tr390
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr391:
+		goto tr233
+	tr390:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st224
 	st224:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof224
 		}
 	st_case_224:
-		// line internal/php8/scanner.go:8911
+		// line internal/php8/scanner.go:8856
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr393
+		case 69:
+			goto tr391
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr393
+			goto tr334
+		case 101:
+			goto tr391
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr393:
+		goto tr233
+	tr229:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st225
 	st225:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof225
 		}
 	st_case_225:
-		// line internal/php8/scanner.go:8952
+		// line internal/php8/scanner.go:8897
 		switch lex.data[(lex.p)] {
-		case 65:
+		case 69:
+			goto tr392
+		case 73:
+			goto tr393
+		case 79:
 			goto tr394
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
+			goto tr334
+		case 101:
+			goto tr392
+		case 105:
+			goto tr393
+		case 111:
 			goto tr394
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr394:
+		goto tr233
+	tr392:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st226
 	st226:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof226
 		}
 	st_case_226:
-		// line internal/php8/scanner.go:8993
+		// line internal/php8/scanner.go:8946
 		switch lex.data[(lex.p)] {
-		case 82:
+		case 67:
 			goto tr395
+		case 70:
+			goto tr396
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
+			goto tr334
+		case 99:
 			goto tr395
+		case 102:
+			goto tr396
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr395:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st227
 	st227:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof227
 		}
 	st_case_227:
-		// line internal/php8/scanner.go:9034
+		// line internal/php8/scanner.go:8991
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr396
+		case 76:
+			goto tr397
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr396
+			goto tr334
+		case 108:
+			goto tr397
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr392:
+		goto tr233
+	tr397:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st228
 	st228:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof228
 		}
 	st_case_228:
-		// line internal/php8/scanner.go:9075
+		// line internal/php8/scanner.go:9032
 		switch lex.data[(lex.p)] {
 		case 65:
-			goto tr397
+			goto tr398
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 97:
-			goto tr397
+			goto tr398
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr397:
+		goto tr233
+	tr398:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st229
 	st229:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof229
 		}
 	st_case_229:
-		// line internal/php8/scanner.go:9116
+		// line internal/php8/scanner.go:9073
 		switch lex.data[(lex.p)] {
-		case 85:
-			goto tr398
+		case 82:
+			goto tr399
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 117:
-			goto tr398
+			goto tr334
+		case 114:
+			goto tr399
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr398:
+		goto tr233
+	tr399:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st230
 	st230:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof230
 		}
 	st_case_230:
-		// line internal/php8/scanner.go:9157
+		// line internal/php8/scanner.go:9114
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr399
+		case 69:
+			goto tr400
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr399
+			goto tr334
+		case 101:
+			goto tr400
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr399:
+		goto tr233
+	tr396:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st231
 	st231:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof231
 		}
 	st_case_231:
-		// line internal/php8/scanner.go:9198
+		// line internal/php8/scanner.go:9155
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr400
+		case 65:
+			goto tr401
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr400
+			goto tr334
+		case 97:
+			goto tr401
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr389:
+		goto tr233
+	tr401:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st232
 	st232:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof232
 		}
 	st_case_232:
-		// line internal/php8/scanner.go:9239
+		// line internal/php8/scanner.go:9196
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr401
+		case 85:
+			goto tr402
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr401
+			goto tr334
+		case 117:
+			goto tr402
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr228:
+		goto tr233
+	tr402:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st233
 	st233:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof233
 		}
 	st_case_233:
-		// line internal/php8/scanner.go:9280
+		// line internal/php8/scanner.go:9237
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr402
 		case 76:
 			goto tr403
-		case 77:
-			goto tr404
-		case 78:
-			goto tr405
-		case 86:
-			goto tr406
-		case 88:
-			goto tr407
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr402
+			goto tr334
 		case 108:
 			goto tr403
-		case 109:
-			goto tr404
-		case 110:
-			goto tr405
-		case 118:
-			goto tr406
-		case 120:
-			goto tr407
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr402:
+		goto tr233
+	tr403:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st234
 	st234:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof234
 		}
 	st_case_234:
-		// line internal/php8/scanner.go:9341
+		// line internal/php8/scanner.go:9278
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr408
+		case 84:
+			goto tr404
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
-			goto tr408
+			goto tr334
+		case 116:
+			goto tr404
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr408:
+		goto tr233
+	tr393:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st235
 	st235:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof235
 		}
 	st_case_235:
-		// line internal/php8/scanner.go:9382
+		// line internal/php8/scanner.go:9319
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr409
+		case 69:
+			goto tr405
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr409
+			goto tr334
+		case 101:
+			goto tr405
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr403:
+		goto tr233
+	tr230:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st236
 	st236:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof236
 		}
 	st_case_236:
-		// line internal/php8/scanner.go:9423
+		// line internal/php8/scanner.go:9360
 		switch lex.data[(lex.p)] {
-		case 83:
+		case 67:
+			goto tr406
+		case 76:
+			goto tr407
+		case 77:
+			goto tr408
+		case 78:
+			goto tr409
+		case 86:
 			goto tr410
+		case 88:
+			goto tr411
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
+			goto tr334
+		case 99:
+			goto tr406
+		case 108:
+			goto tr407
+		case 109:
+			goto tr408
+		case 110:
+			goto tr409
+		case 118:
 			goto tr410
+		case 120:
+			goto tr411
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr410:
+		goto tr233
+	tr406:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st237
 	st237:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof237
 		}
 	st_case_237:
-		// line internal/php8/scanner.go:9464
+		// line internal/php8/scanner.go:9421
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr411
+		case 72:
+			goto tr412
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr411
+			goto tr334
+		case 104:
+			goto tr412
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr411:
+		goto tr233
+	tr412:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:222
-		lex.act = 33
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st238
 	st238:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof238
 		}
 	st_case_238:
-		// line internal/php8/scanner.go:9505
+		// line internal/php8/scanner.go:9462
 		switch lex.data[(lex.p)] {
-		case 73:
+		case 79:
 			goto tr413
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr412
-		case 105:
+			goto tr334
+		case 111:
 			goto tr413
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr412
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr412
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr412
+				goto tr334
 			}
 		default:
-			goto tr412
+			goto tr334
 		}
-		goto tr231
-	tr413:
+		goto tr233
+	tr407:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st239
 	st239:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof239
 		}
 	st_case_239:
-		// line internal/php8/scanner.go:9546
+		// line internal/php8/scanner.go:9503
 		switch lex.data[(lex.p)] {
-		case 70:
+		case 83:
 			goto tr414
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 102:
+			goto tr334
+		case 115:
 			goto tr414
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr404:
+		goto tr233
+	tr414:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st240
 	st240:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof240
 		}
 	st_case_240:
-		// line internal/php8/scanner.go:9587
+		// line internal/php8/scanner.go:9544
 		switch lex.data[(lex.p)] {
-		case 80:
+		case 69:
 			goto tr415
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 112:
+			goto tr334
+		case 101:
 			goto tr415
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr415:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:233
+		lex.act = 34
 		goto st241
 	st241:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof241
 		}
 	st_case_241:
-		// line internal/php8/scanner.go:9628
+		// line internal/php8/scanner.go:9585
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr416
+		case 73:
+			goto tr417
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
 			goto tr416
+		case 105:
+			goto tr417
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr416
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr416
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr416
 			}
 		default:
-			goto tr330
+			goto tr416
 		}
-		goto tr231
-	tr416:
+		goto tr233
+	tr417:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st242
 	st242:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof242
 		}
 	st_case_242:
-		// line internal/php8/scanner.go:9669
+		// line internal/php8/scanner.go:9626
 		switch lex.data[(lex.p)] {
-		case 89:
-			goto tr417
+		case 70:
+			goto tr418
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 121:
-			goto tr417
+			goto tr334
+		case 102:
+			goto tr418
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr405:
+		goto tr233
+	tr408:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st243
 	st243:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof243
 		}
 	st_case_243:
-		// line internal/php8/scanner.go:9710
+		// line internal/php8/scanner.go:9667
 		switch lex.data[(lex.p)] {
-		case 68:
-			goto tr418
+		case 80:
+			goto tr419
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 100:
-			goto tr418
+			goto tr334
+		case 112:
+			goto tr419
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr418:
+		goto tr233
+	tr419:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st244
 	st244:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof244
 		}
 	st_case_244:
-		// line internal/php8/scanner.go:9751
+		// line internal/php8/scanner.go:9708
 		switch lex.data[(lex.p)] {
-		case 68:
-			goto tr419
-		case 70:
+		case 84:
 			goto tr420
-		case 73:
-			goto tr421
-		case 83:
-			goto tr422
-		case 87:
-			goto tr423
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 100:
-			goto tr419
-		case 102:
+			goto tr334
+		case 116:
 			goto tr420
-		case 105:
-			goto tr421
-		case 115:
-			goto tr422
-		case 119:
-			goto tr423
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr419:
+		goto tr233
+	tr420:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st245
 	st245:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof245
 		}
 	st_case_245:
-		// line internal/php8/scanner.go:9808
+		// line internal/php8/scanner.go:9749
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr424
+		case 89:
+			goto tr421
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr424
+			goto tr334
+		case 121:
+			goto tr421
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr424:
+		goto tr233
+	tr409:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st246
 	st246:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof246
 		}
 	st_case_246:
-		// line internal/php8/scanner.go:9849
+		// line internal/php8/scanner.go:9790
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr425
+		case 68:
+			goto tr422
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr425
+			goto tr334
+		case 100:
+			goto tr422
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr425:
+		goto tr233
+	tr422:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st247
 	st247:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof247
 		}
 	st_case_247:
-		// line internal/php8/scanner.go:9890
+		// line internal/php8/scanner.go:9831
 		switch lex.data[(lex.p)] {
-		case 76:
+		case 68:
+			goto tr423
+		case 70:
+			goto tr424
+		case 73:
+			goto tr425
+		case 83:
 			goto tr426
+		case 87:
+			goto tr427
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
+			goto tr334
+		case 100:
+			goto tr423
+		case 102:
+			goto tr424
+		case 105:
+			goto tr425
+		case 115:
 			goto tr426
+		case 119:
+			goto tr427
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr426:
+		goto tr233
+	tr423:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st248
 	st248:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof248
 		}
 	st_case_248:
-		// line internal/php8/scanner.go:9931
+		// line internal/php8/scanner.go:9888
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr427
+		case 69:
+			goto tr428
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr427
+			goto tr334
+		case 101:
+			goto tr428
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr427:
+		goto tr233
+	tr428:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st249
 	st249:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof249
 		}
 	st_case_249:
-		// line internal/php8/scanner.go:9972
+		// line internal/php8/scanner.go:9929
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr428
+		case 67:
+			goto tr429
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr428
+			goto tr334
+		case 99:
+			goto tr429
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr428:
+		goto tr233
+	tr429:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st250
 	st250:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof250
 		}
 	st_case_250:
-		// line internal/php8/scanner.go:10013
+		// line internal/php8/scanner.go:9970
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr429
+		case 76:
+			goto tr430
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr429
+			goto tr334
+		case 108:
+			goto tr430
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr420:
+		goto tr233
+	tr430:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st251
 	st251:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof251
 		}
 	st_case_251:
-		// line internal/php8/scanner.go:10054
+		// line internal/php8/scanner.go:10011
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr430
+		case 65:
+			goto tr431
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr430
+			goto tr334
+		case 97:
+			goto tr431
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr430:
+		goto tr233
+	tr431:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st252
 	st252:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof252
 		}
 	st_case_252:
-		// line internal/php8/scanner.go:10095
+		// line internal/php8/scanner.go:10052
 		switch lex.data[(lex.p)] {
 		case 82:
-			goto tr431
+			goto tr432
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 114:
-			goto tr431
+			goto tr432
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr431:
+		goto tr233
+	tr432:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:226
-		lex.act = 37
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st253
 	st253:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof253
 		}
 	st_case_253:
-		// line internal/php8/scanner.go:10136
+		// line internal/php8/scanner.go:10093
 		switch lex.data[(lex.p)] {
 		case 69:
 			goto tr433
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr432
+			goto tr334
 		case 101:
 			goto tr433
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr432
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr432
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr432
+				goto tr334
 			}
 		default:
-			goto tr432
+			goto tr334
 		}
-		goto tr231
-	tr433:
+		goto tr233
+	tr424:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st254
 	st254:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof254
 		}
 	st_case_254:
-		// line internal/php8/scanner.go:10177
+		// line internal/php8/scanner.go:10134
 		switch lex.data[(lex.p)] {
-		case 65:
+		case 79:
 			goto tr434
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
+			goto tr334
+		case 111:
 			goto tr434
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr434:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st255
 	st255:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof255
 		}
 	st_case_255:
-		// line internal/php8/scanner.go:10218
+		// line internal/php8/scanner.go:10175
 		switch lex.data[(lex.p)] {
-		case 67:
+		case 82:
 			goto tr435
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
+			goto tr334
+		case 114:
 			goto tr435
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr435:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:237
+		lex.act = 38
 		goto st256
 	st256:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof256
 		}
 	st_case_256:
-		// line internal/php8/scanner.go:10259
+		// line internal/php8/scanner.go:10216
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr436
+		case 69:
+			goto tr437
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
 			goto tr436
+		case 101:
+			goto tr437
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr436
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr436
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr436
 			}
 		default:
-			goto tr330
+			goto tr436
 		}
-		goto tr231
-	tr421:
+		goto tr233
+	tr437:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st257
 	st257:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof257
 		}
 	st_case_257:
-		// line internal/php8/scanner.go:10300
+		// line internal/php8/scanner.go:10257
 		switch lex.data[(lex.p)] {
-		case 70:
-			goto tr437
+		case 65:
+			goto tr438
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 102:
-			goto tr437
+			goto tr334
+		case 97:
+			goto tr438
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr422:
+		goto tr233
+	tr438:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st258
 	st258:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof258
 		}
 	st_case_258:
-		// line internal/php8/scanner.go:10341
+		// line internal/php8/scanner.go:10298
 		switch lex.data[(lex.p)] {
-		case 87:
-			goto tr438
+		case 67:
+			goto tr439
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 119:
-			goto tr438
+			goto tr334
+		case 99:
+			goto tr439
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr438:
+		goto tr233
+	tr439:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st259
 	st259:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof259
 		}
 	st_case_259:
-		// line internal/php8/scanner.go:10382
+		// line internal/php8/scanner.go:10339
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr439
+		case 72:
+			goto tr440
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr439
+			goto tr334
+		case 104:
+			goto tr440
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr439:
+		goto tr233
+	tr425:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st260
 	st260:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof260
 		}
 	st_case_260:
-		// line internal/php8/scanner.go:10423
+		// line internal/php8/scanner.go:10380
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr440
+		case 70:
+			goto tr441
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr440
+			goto tr334
+		case 102:
+			goto tr441
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr440:
+		goto tr233
+	tr426:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st261
 	st261:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof261
 		}
 	st_case_261:
-		// line internal/php8/scanner.go:10464
+		// line internal/php8/scanner.go:10421
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr441
+		case 87:
+			goto tr442
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr441
+			goto tr334
+		case 119:
+			goto tr442
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr441:
+		goto tr233
+	tr442:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st262
 	st262:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof262
 		}
 	st_case_262:
-		// line internal/php8/scanner.go:10505
+		// line internal/php8/scanner.go:10462
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr442
+		case 73:
+			goto tr443
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
-			goto tr442
+			goto tr334
+		case 105:
+			goto tr443
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr423:
+		goto tr233
+	tr443:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st263
 	st263:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof263
 		}
 	st_case_263:
-		// line internal/php8/scanner.go:10546
+		// line internal/php8/scanner.go:10503
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr443
+		case 84:
+			goto tr444
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
-			goto tr443
+			goto tr334
+		case 116:
+			goto tr444
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr443:
+		goto tr233
+	tr444:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st264
 	st264:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof264
 		}
 	st_case_264:
-		// line internal/php8/scanner.go:10587
+		// line internal/php8/scanner.go:10544
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr444
+		case 67:
+			goto tr445
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr444
+			goto tr334
+		case 99:
+			goto tr445
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr444:
+		goto tr233
+	tr445:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st265
 	st265:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof265
 		}
 	st_case_265:
-		// line internal/php8/scanner.go:10628
+		// line internal/php8/scanner.go:10585
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr445
+		case 72:
+			goto tr446
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr445
+			goto tr334
+		case 104:
+			goto tr446
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr445:
+		goto tr233
+	tr427:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st266
 	st266:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof266
 		}
 	st_case_266:
-		// line internal/php8/scanner.go:10669
+		// line internal/php8/scanner.go:10626
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr446
+		case 72:
+			goto tr447
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr446
+			goto tr334
+		case 104:
+			goto tr447
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr406:
+		goto tr233
+	tr447:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st267
 	st267:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof267
 		}
 	st_case_267:
-		// line internal/php8/scanner.go:10710
+		// line internal/php8/scanner.go:10667
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr447
+		case 73:
+			goto tr448
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr447
+			goto tr334
+		case 105:
+			goto tr448
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr447:
+		goto tr233
+	tr448:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st268
 	st268:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof268
 		}
 	st_case_268:
-		// line internal/php8/scanner.go:10751
+		// line internal/php8/scanner.go:10708
 		switch lex.data[(lex.p)] {
 		case 76:
-			goto tr448
+			goto tr449
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 108:
-			goto tr448
+			goto tr449
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr407:
+		goto tr233
+	tr449:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st269
 	st269:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof269
 		}
 	st_case_269:
-		// line internal/php8/scanner.go:10792
+		// line internal/php8/scanner.go:10749
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr449
-		case 84:
+		case 69:
 			goto tr450
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr449
-		case 116:
+			goto tr334
+		case 101:
 			goto tr450
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr449:
+		goto tr233
+	tr410:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st270
 	st270:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof270
 		}
 	st_case_270:
-		// line internal/php8/scanner.go:10837
+		// line internal/php8/scanner.go:10790
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr401
+		case 65:
+			goto tr451
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr401
+			goto tr334
+		case 97:
+			goto tr451
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr450:
+		goto tr233
+	tr451:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st271
 	st271:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof271
 		}
 	st_case_271:
-		// line internal/php8/scanner.go:10878
+		// line internal/php8/scanner.go:10831
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr451
+		case 76:
+			goto tr452
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr451
+			goto tr334
+		case 108:
+			goto tr452
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr451:
+		goto tr233
+	tr411:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st272
 	st272:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof272
 		}
 	st_case_272:
-		// line internal/php8/scanner.go:10919
+		// line internal/php8/scanner.go:10872
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr452
+		case 73:
+			goto tr453
+		case 84:
+			goto tr454
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr452
+			goto tr334
+		case 105:
+			goto tr453
+		case 116:
+			goto tr454
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr452:
+		goto tr233
+	tr453:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st273
 	st273:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof273
 		}
 	st_case_273:
-		// line internal/php8/scanner.go:10960
+		// line internal/php8/scanner.go:10917
 		switch lex.data[(lex.p)] {
-		case 68:
-			goto tr453
+		case 84:
+			goto tr405
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 100:
-			goto tr453
+			goto tr334
+		case 116:
+			goto tr405
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr453:
+		goto tr233
+	tr454:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st274
 	st274:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof274
 		}
 	st_case_274:
-		// line internal/php8/scanner.go:11001
+		// line internal/php8/scanner.go:10958
 		switch lex.data[(lex.p)] {
-		case 83:
-			goto tr454
+		case 69:
+			goto tr455
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
-			goto tr454
+			goto tr334
+		case 101:
+			goto tr455
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr229:
+		goto tr233
+	tr455:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st275
 	st275:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof275
 		}
 	st_case_275:
-		// line internal/php8/scanner.go:11042
+		// line internal/php8/scanner.go:10999
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr455
 		case 78:
 			goto tr456
-		case 79:
-			goto tr457
-		case 85:
-			goto tr367
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr455
+			goto tr334
 		case 110:
 			goto tr456
-		case 111:
-			goto tr457
-		case 117:
-			goto tr367
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr455:
+		goto tr233
+	tr456:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st276
 	st276:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof276
 		}
 	st_case_276:
-		// line internal/php8/scanner.go:11095
+		// line internal/php8/scanner.go:11040
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr458
+		case 68:
+			goto tr457
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr458
+			goto tr334
+		case 100:
+			goto tr457
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr458:
+		goto tr233
+	tr457:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st277
 	st277:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof277
 		}
 	st_case_277:
-		// line internal/php8/scanner.go:11136
+		// line internal/php8/scanner.go:11081
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr459
+		case 83:
+			goto tr458
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr459
+			goto tr334
+		case 115:
+			goto tr458
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr459:
+		goto tr233
+	tr231:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st278
 	st278:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof278
 		}
 	st_case_278:
-		// line internal/php8/scanner.go:11177
+		// line internal/php8/scanner.go:11122
 		switch lex.data[(lex.p)] {
-		case 76:
+		case 73:
+			goto tr459
+		case 78:
 			goto tr460
+		case 79:
+			goto tr461
+		case 85:
+			goto tr371
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
+			goto tr334
+		case 105:
+			goto tr459
+		case 110:
 			goto tr460
+		case 111:
+			goto tr461
+		case 117:
+			goto tr371
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr460:
+		goto tr233
+	tr459:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:234
-		lex.act = 45
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st279
 	st279:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof279
 		}
 	st_case_279:
-		// line internal/php8/scanner.go:11218
+		// line internal/php8/scanner.go:11175
 		switch lex.data[(lex.p)] {
-		case 76:
+		case 78:
 			goto tr462
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr461
-		case 108:
+			goto tr334
+		case 110:
 			goto tr462
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr461
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr461
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr461
+				goto tr334
 			}
 		default:
-			goto tr461
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr462:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st280
 	st280:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof280
 		}
 	st_case_280:
-		// line internal/php8/scanner.go:11259
+		// line internal/php8/scanner.go:11216
 		switch lex.data[(lex.p)] {
-		case 89:
+		case 65:
 			goto tr463
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 121:
+			goto tr334
+		case 97:
 			goto tr463
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr457:
+		goto tr233
+	tr463:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st281
 	st281:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof281
 		}
 	st_case_281:
-		// line internal/php8/scanner.go:11300
+		// line internal/php8/scanner.go:11257
 		switch lex.data[(lex.p)] {
-		case 82:
+		case 76:
 			goto tr464
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
+			goto tr334
+		case 108:
 			goto tr464
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr464:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:236
-		lex.act = 47
+		// line internal/php8/scanner.rl:245
+		lex.act = 46
 		goto st282
 	st282:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof282
 		}
 	st_case_282:
-		// line internal/php8/scanner.go:11341
+		// line internal/php8/scanner.go:11298
 		switch lex.data[(lex.p)] {
-		case 69:
+		case 76:
 			goto tr466
 		case 92:
-			goto st93
+			goto st94
 		case 96:
 			goto tr465
-		case 101:
+		case 108:
 			goto tr466
 		}
 		switch {
@@ -12636,2701 +12616,2824 @@ func (lex *Lexer) Lex() *token.Token {
 		default:
 			goto tr465
 		}
-		goto tr231
+		goto tr233
 	tr466:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st283
 	st283:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof283
 		}
 	st_case_283:
-		// line internal/php8/scanner.go:11382
+		// line internal/php8/scanner.go:11339
 		switch lex.data[(lex.p)] {
-		case 65:
+		case 89:
 			goto tr467
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
+			goto tr334
+		case 121:
 			goto tr467
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr467:
+		goto tr233
+	tr461:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st284
 	st284:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof284
 		}
 	st_case_284:
-		// line internal/php8/scanner.go:11423
+		// line internal/php8/scanner.go:11380
 		switch lex.data[(lex.p)] {
-		case 67:
+		case 82:
 			goto tr468
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
+			goto tr334
+		case 114:
 			goto tr468
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr468:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:247
+		lex.act = 48
 		goto st285
 	st285:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof285
 		}
 	st_case_285:
-		// line internal/php8/scanner.go:11464
+		// line internal/php8/scanner.go:11421
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr469
+		case 69:
+			goto tr470
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
 			goto tr469
+		case 101:
+			goto tr470
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr469
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr469
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr469
 			}
 		default:
-			goto tr330
+			goto tr469
 		}
-		goto tr231
-	tr230:
+		goto tr233
+	tr470:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st286
 	st286:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof286
 		}
 	st_case_286:
-		// line internal/php8/scanner.go:11505
+		// line internal/php8/scanner.go:11462
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr470
-		case 79:
+		case 65:
 			goto tr471
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr470
-		case 111:
+			goto tr334
+		case 97:
 			goto tr471
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr470:
+		goto tr233
+	tr471:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st287
 	st287:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof287
 		}
 	st_case_287:
-		// line internal/php8/scanner.go:11550
+		// line internal/php8/scanner.go:11503
 		switch lex.data[(lex.p)] {
-		case 79:
+		case 67:
 			goto tr472
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
+			goto tr334
+		case 99:
 			goto tr472
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr472:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st288
 	st288:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof288
 		}
 	st_case_288:
-		// line internal/php8/scanner.go:11591
+		// line internal/php8/scanner.go:11544
 		switch lex.data[(lex.p)] {
-		case 66:
+		case 72:
 			goto tr473
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 98:
+			goto tr334
+		case 104:
 			goto tr473
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr473:
+		goto tr233
+	tr232:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st289
 	st289:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof289
 		}
 	st_case_289:
-		// line internal/php8/scanner.go:11632
+		// line internal/php8/scanner.go:11585
 		switch lex.data[(lex.p)] {
-		case 65:
+		case 76:
 			goto tr474
+		case 79:
+			goto tr475
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
+			goto tr334
+		case 108:
 			goto tr474
+		case 111:
+			goto tr475
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr474:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st290
 	st290:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof290
 		}
 	st_case_290:
-		// line internal/php8/scanner.go:11673
+		// line internal/php8/scanner.go:11630
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr475
+		case 79:
+			goto tr476
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr475
+			goto tr334
+		case 111:
+			goto tr476
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr471:
+		goto tr233
+	tr476:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st291
 	st291:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof291
 		}
 	st_case_291:
-		// line internal/php8/scanner.go:11714
+		// line internal/php8/scanner.go:11671
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr476
+		case 66:
+			goto tr477
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr476
+			goto tr334
+		case 98:
+			goto tr477
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr476:
+		goto tr233
+	tr477:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st292
 	st292:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof292
 		}
 	st_case_292:
-		// line internal/php8/scanner.go:11755
+		// line internal/php8/scanner.go:11712
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr477
+		case 65:
+			goto tr478
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr477
+			goto tr334
+		case 97:
+			goto tr478
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr232:
+		goto tr233
+	tr478:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st293
 	st293:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof293
 		}
 	st_case_293:
-		// line internal/php8/scanner.go:11796
+		// line internal/php8/scanner.go:11753
 		switch lex.data[(lex.p)] {
-		case 70:
-			goto tr478
-		case 77:
+		case 76:
 			goto tr479
-		case 78:
-			goto tr480
-		case 83:
-			goto tr481
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 102:
-			goto tr478
-		case 109:
+			goto tr334
+		case 108:
 			goto tr479
-		case 110:
-			goto tr480
-		case 115:
-			goto tr481
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr479:
+		goto tr233
+	tr475:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st294
 	st294:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof294
 		}
 	st_case_294:
-		// line internal/php8/scanner.go:11849
+		// line internal/php8/scanner.go:11794
 		switch lex.data[(lex.p)] {
-		case 80:
-			goto tr482
+		case 84:
+			goto tr480
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 112:
-			goto tr482
+			goto tr334
+		case 116:
+			goto tr480
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr482:
+		goto tr233
+	tr480:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st295
 	st295:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof295
 		}
 	st_case_295:
-		// line internal/php8/scanner.go:11890
+		// line internal/php8/scanner.go:11835
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr483
+		case 79:
+			goto tr481
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr483
+			goto tr334
+		case 111:
+			goto tr481
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr483:
+		goto tr233
+	tr234:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st296
 	st296:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof296
 		}
 	st_case_296:
-		// line internal/php8/scanner.go:11931
+		// line internal/php8/scanner.go:11876
 		switch lex.data[(lex.p)] {
-		case 69:
+		case 70:
+			goto tr482
+		case 77:
+			goto tr483
+		case 78:
 			goto tr484
+		case 83:
+			goto tr485
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
+			goto tr334
+		case 102:
+			goto tr482
+		case 109:
+			goto tr483
+		case 110:
 			goto tr484
+		case 115:
+			goto tr485
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr484:
+		goto tr233
+	tr483:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st297
 	st297:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof297
 		}
 	st_case_297:
-		// line internal/php8/scanner.go:11972
+		// line internal/php8/scanner.go:11929
 		switch lex.data[(lex.p)] {
-		case 77:
-			goto tr485
+		case 80:
+			goto tr486
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 109:
-			goto tr485
+			goto tr334
+		case 112:
+			goto tr486
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr485:
+		goto tr233
+	tr486:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st298
 	st298:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof298
 		}
 	st_case_298:
-		// line internal/php8/scanner.go:12013
+		// line internal/php8/scanner.go:11970
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr486
+		case 76:
+			goto tr487
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr486
+			goto tr334
+		case 108:
+			goto tr487
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr486:
+		goto tr233
+	tr487:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st299
 	st299:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof299
 		}
 	st_case_299:
-		// line internal/php8/scanner.go:12054
+		// line internal/php8/scanner.go:12011
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr487
+		case 69:
+			goto tr488
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr487
+			goto tr334
+		case 101:
+			goto tr488
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr487:
+		goto tr233
+	tr488:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st300
 	st300:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof300
 		}
 	st_case_300:
-		// line internal/php8/scanner.go:12095
+		// line internal/php8/scanner.go:12052
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr488
+		case 77:
+			goto tr489
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr488
+			goto tr334
+		case 109:
+			goto tr489
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr488:
+		goto tr233
+	tr489:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st301
 	st301:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof301
 		}
 	st_case_301:
-		// line internal/php8/scanner.go:12136
+		// line internal/php8/scanner.go:12093
 		switch lex.data[(lex.p)] {
-		case 83:
-			goto tr489
+		case 69:
+			goto tr490
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
-			goto tr489
+			goto tr334
+		case 101:
+			goto tr490
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr480:
+		goto tr233
+	tr490:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st302
 	st302:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof302
 		}
 	st_case_302:
-		// line internal/php8/scanner.go:12177
+		// line internal/php8/scanner.go:12134
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr490
-		case 83:
+		case 78:
 			goto tr491
-		case 84:
-			goto tr492
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr490
-		case 115:
+			goto tr334
+		case 110:
 			goto tr491
-		case 116:
-			goto tr492
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr490:
+		goto tr233
+	tr491:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st303
 	st303:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof303
 		}
 	st_case_303:
-		// line internal/php8/scanner.go:12226
+		// line internal/php8/scanner.go:12175
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr493
+		case 84:
+			goto tr492
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr493
+			goto tr334
+		case 116:
+			goto tr492
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr493:
+		goto tr233
+	tr492:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st304
 	st304:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof304
 		}
 	st_case_304:
-		// line internal/php8/scanner.go:12267
+		// line internal/php8/scanner.go:12216
 		switch lex.data[(lex.p)] {
-		case 85:
-			goto tr494
+		case 83:
+			goto tr493
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 117:
-			goto tr494
+			goto tr334
+		case 115:
+			goto tr493
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr494:
+		goto tr233
+	tr484:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st305
 	st305:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof305
 		}
 	st_case_305:
-		// line internal/php8/scanner.go:12308
+		// line internal/php8/scanner.go:12257
 		switch lex.data[(lex.p)] {
-		case 68:
+		case 67:
+			goto tr494
+		case 83:
 			goto tr495
+		case 84:
+			goto tr496
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 100:
+			goto tr334
+		case 99:
+			goto tr494
+		case 115:
 			goto tr495
+		case 116:
+			goto tr496
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr495:
+		goto tr233
+	tr494:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st306
 	st306:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof306
 		}
 	st_case_306:
-		// line internal/php8/scanner.go:12349
+		// line internal/php8/scanner.go:12306
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr496
+		case 76:
+			goto tr497
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr496
+			goto tr334
+		case 108:
+			goto tr497
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr496:
+		goto tr233
+	tr497:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:268
-		lex.act = 79
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st307
 	st307:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof307
 		}
 	st_case_307:
-		// line internal/php8/scanner.go:12390
+		// line internal/php8/scanner.go:12347
 		switch lex.data[(lex.p)] {
+		case 85:
+			goto tr498
 		case 92:
-			goto st93
-		case 95:
+			goto st94
+		case 96:
+			goto tr334
+		case 117:
 			goto tr498
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr497
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr497
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr497
+				goto tr334
 			}
 		default:
-			goto tr497
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr498:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st308
 	st308:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof308
 		}
 	st_case_308:
-		// line internal/php8/scanner.go:12427
+		// line internal/php8/scanner.go:12388
 		switch lex.data[(lex.p)] {
-		case 79:
+		case 68:
 			goto tr499
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
+			goto tr334
+		case 100:
 			goto tr499
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr499:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st309
 	st309:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof309
 		}
 	st_case_309:
-		// line internal/php8/scanner.go:12468
+		// line internal/php8/scanner.go:12429
 		switch lex.data[(lex.p)] {
-		case 78:
+		case 69:
 			goto tr500
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
+			goto tr334
+		case 101:
 			goto tr500
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr500:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:279
+		lex.act = 80
 		goto st310
 	st310:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof310
 		}
 	st_case_310:
-		// line internal/php8/scanner.go:12509
+		// line internal/php8/scanner.go:12470
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr501
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 99:
-			goto tr501
+			goto st94
+		case 95:
+			goto tr502
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr501
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr501
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr501
 			}
 		default:
-			goto tr330
+			goto tr501
 		}
-		goto tr231
-	tr501:
+		goto tr233
+	tr502:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st311
 	st311:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof311
 		}
 	st_case_311:
-		// line internal/php8/scanner.go:12550
+		// line internal/php8/scanner.go:12507
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr502
+		case 79:
+			goto tr503
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr502
+			goto tr334
+		case 111:
+			goto tr503
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr491:
+		goto tr233
+	tr503:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st312
 	st312:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof312
 		}
 	st_case_312:
-		// line internal/php8/scanner.go:12591
+		// line internal/php8/scanner.go:12548
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr503
+		case 78:
+			goto tr504
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr503
+			goto tr334
+		case 110:
+			goto tr504
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr503:
+		goto tr233
+	tr504:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st313
 	st313:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof313
 		}
 	st_case_313:
-		// line internal/php8/scanner.go:12632
+		// line internal/php8/scanner.go:12589
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr504
-		case 69:
+		case 67:
 			goto tr505
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr504
-		case 101:
+			goto tr334
+		case 99:
 			goto tr505
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr504:
+		goto tr233
+	tr505:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st314
 	st314:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof314
 		}
 	st_case_314:
-		// line internal/php8/scanner.go:12677
+		// line internal/php8/scanner.go:12630
 		switch lex.data[(lex.p)] {
-		case 78:
+		case 69:
 			goto tr506
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
+			goto tr334
+		case 101:
 			goto tr506
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr506:
+		goto tr233
+	tr495:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st315
 	st315:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof315
 		}
 	st_case_315:
-		// line internal/php8/scanner.go:12718
+		// line internal/php8/scanner.go:12671
 		switch lex.data[(lex.p)] {
-		case 67:
+		case 84:
 			goto tr507
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
+			goto tr334
+		case 116:
 			goto tr507
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr507:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st316
 	st316:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof316
 		}
 	st_case_316:
-		// line internal/php8/scanner.go:12759
+		// line internal/php8/scanner.go:12712
 		switch lex.data[(lex.p)] {
+		case 65:
+			goto tr508
 		case 69:
-			goto tr508
+			goto tr509
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
+			goto tr334
+		case 97:
 			goto tr508
+		case 101:
+			goto tr509
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr508:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st317
 	st317:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof317
 		}
 	st_case_317:
-		// line internal/php8/scanner.go:12800
+		// line internal/php8/scanner.go:12757
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr509
+		case 78:
+			goto tr510
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr509
+			goto tr334
+		case 110:
+			goto tr510
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr509:
+		goto tr233
+	tr510:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st318
 	st318:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof318
 		}
 	st_case_318:
-		// line internal/php8/scanner.go:12841
+		// line internal/php8/scanner.go:12798
 		switch lex.data[(lex.p)] {
-		case 70:
-			goto tr510
+		case 67:
+			goto tr511
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 102:
-			goto tr510
+			goto tr334
+		case 99:
+			goto tr511
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr505:
+		goto tr233
+	tr511:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st319
 	st319:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof319
 		}
 	st_case_319:
-		// line internal/php8/scanner.go:12882
+		// line internal/php8/scanner.go:12839
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr511
+		case 69:
+			goto tr512
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr511
+			goto tr334
+		case 101:
+			goto tr512
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr511:
+		goto tr233
+	tr512:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st320
 	st320:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof320
 		}
 	st_case_320:
-		// line internal/php8/scanner.go:12923
-		switch lex.data[(lex.p)] {
-		case 68:
-			goto tr512
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 100:
-			goto tr512
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr512:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st321
-	st321:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof321
-		}
-	st_case_321:
-		// line internal/php8/scanner.go:12964
+		// line internal/php8/scanner.go:12880
 		switch lex.data[(lex.p)] {
 		case 79:
 			goto tr513
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 111:
 			goto tr513
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr513:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st321
+	st321:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof321
+		}
+	st_case_321:
+		// line internal/php8/scanner.go:12921
+		switch lex.data[(lex.p)] {
+		case 70:
+			goto tr514
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 102:
+			goto tr514
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr509:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st322
 	st322:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof322
 		}
 	st_case_322:
-		// line internal/php8/scanner.go:13005
+		// line internal/php8/scanner.go:12962
 		switch lex.data[(lex.p)] {
-		case 70:
-			goto tr514
+		case 65:
+			goto tr515
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 102:
-			goto tr514
+			goto tr334
+		case 97:
+			goto tr515
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr492:
+		goto tr233
+	tr515:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st323
 	st323:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof323
 		}
 	st_case_323:
-		// line internal/php8/scanner.go:13046
+		// line internal/php8/scanner.go:13003
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr515
+		case 68:
+			goto tr516
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr515
+			goto tr334
+		case 100:
+			goto tr516
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr515:
+		goto tr233
+	tr516:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st324
 	st324:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof324
 		}
 	st_case_324:
-		// line internal/php8/scanner.go:13087
+		// line internal/php8/scanner.go:13044
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr516
+		case 79:
+			goto tr517
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr516
+			goto tr334
+		case 111:
+			goto tr517
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr516:
+		goto tr233
+	tr517:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st325
 	st325:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof325
 		}
 	st_case_325:
-		// line internal/php8/scanner.go:13128
+		// line internal/php8/scanner.go:13085
 		switch lex.data[(lex.p)] {
 		case 70:
-			goto tr517
+			goto tr518
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 102:
-			goto tr517
+			goto tr518
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr517:
+		goto tr233
+	tr496:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st326
 	st326:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof326
 		}
 	st_case_326:
-		// line internal/php8/scanner.go:13169
+		// line internal/php8/scanner.go:13126
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr518
+		case 69:
+			goto tr519
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr518
+			goto tr334
+		case 101:
+			goto tr519
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr518:
+		goto tr233
+	tr519:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st327
 	st327:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof327
 		}
 	st_case_327:
-		// line internal/php8/scanner.go:13210
+		// line internal/php8/scanner.go:13167
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr519
+		case 82:
+			goto tr520
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr519
+			goto tr334
+		case 114:
+			goto tr520
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr519:
+		goto tr233
+	tr520:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st328
 	st328:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof328
 		}
 	st_case_328:
-		// line internal/php8/scanner.go:13251
+		// line internal/php8/scanner.go:13208
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr520
+		case 70:
+			goto tr521
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr520
+			goto tr334
+		case 102:
+			goto tr521
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr481:
+		goto tr233
+	tr521:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st329
 	st329:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof329
 		}
 	st_case_329:
-		// line internal/php8/scanner.go:13292
+		// line internal/php8/scanner.go:13249
 		switch lex.data[(lex.p)] {
-		case 83:
-			goto tr521
+		case 65:
+			goto tr522
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
-			goto tr521
+			goto tr334
+		case 97:
+			goto tr522
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr521:
+		goto tr233
+	tr522:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st330
 	st330:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof330
 		}
 	st_case_330:
-		// line internal/php8/scanner.go:13333
+		// line internal/php8/scanner.go:13290
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr522
+		case 67:
+			goto tr523
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr522
+			goto tr334
+		case 99:
+			goto tr523
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr522:
+		goto tr233
+	tr523:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st331
 	st331:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof331
 		}
 	st_case_331:
-		// line internal/php8/scanner.go:13374
+		// line internal/php8/scanner.go:13331
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr523
+		case 69:
+			goto tr524
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr523
+			goto tr334
+		case 101:
+			goto tr524
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr233:
+		goto tr233
+	tr485:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st332
 	st332:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof332
 		}
 	st_case_332:
-		// line internal/php8/scanner.go:13415
+		// line internal/php8/scanner.go:13372
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr524
+		case 83:
+			goto tr525
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr524
+			goto tr334
+		case 115:
+			goto tr525
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr524:
+		goto tr233
+	tr525:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st333
 	st333:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof333
 		}
 	st_case_333:
-		// line internal/php8/scanner.go:13456
+		// line internal/php8/scanner.go:13413
 		switch lex.data[(lex.p)] {
-		case 83:
-			goto tr525
+		case 69:
+			goto tr526
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
-			goto tr525
+			goto tr334
+		case 101:
+			goto tr526
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr525:
+		goto tr233
+	tr526:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st334
 	st334:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof334
 		}
 	st_case_334:
-		// line internal/php8/scanner.go:13497
+		// line internal/php8/scanner.go:13454
 		switch lex.data[(lex.p)] {
 		case 84:
-			goto tr526
+			goto tr527
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 116:
-			goto tr526
+			goto tr527
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr234:
+		goto tr233
+	tr235:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st335
 	st335:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof335
 		}
 	st_case_335:
-		// line internal/php8/scanner.go:13538
+		// line internal/php8/scanner.go:13495
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr527
+		case 73:
+			goto tr528
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr527
+			goto tr334
+		case 105:
+			goto tr528
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr527:
+		goto tr233
+	tr528:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st336
 	st336:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof336
 		}
 	st_case_336:
-		// line internal/php8/scanner.go:13579
+		// line internal/php8/scanner.go:13536
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr528
+		case 83:
+			goto tr529
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr528
+			goto tr334
+		case 115:
+			goto tr529
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr528:
+		goto tr233
+	tr529:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st337
 	st337:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof337
 		}
 	st_case_337:
-		// line internal/php8/scanner.go:13620
+		// line internal/php8/scanner.go:13577
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr529
+		case 84:
+			goto tr530
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr529
+			goto tr334
+		case 116:
+			goto tr530
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr529:
+		goto tr233
+	tr236:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st338
 	st338:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof338
 		}
 	st_case_338:
-		// line internal/php8/scanner.go:13661
+		// line internal/php8/scanner.go:13618
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr530
+		case 65:
+			goto tr531
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
-			goto tr530
+			goto tr334
+		case 97:
+			goto tr531
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr235:
+		goto tr233
+	tr531:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st339
 	st339:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof339
 		}
 	st_case_339:
-		// line internal/php8/scanner.go:13702
+		// line internal/php8/scanner.go:13659
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr531
-		case 69:
+		case 84:
 			goto tr532
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr531
-		case 101:
+			goto tr334
+		case 116:
 			goto tr532
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr531:
+		goto tr233
+	tr532:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st340
 	st340:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof340
 		}
 	st_case_340:
-		// line internal/php8/scanner.go:13747
+		// line internal/php8/scanner.go:13700
 		switch lex.data[(lex.p)] {
-		case 77:
+		case 67:
 			goto tr533
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 109:
+			goto tr334
+		case 99:
 			goto tr533
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr533:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st341
 	st341:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof341
 		}
 	st_case_341:
-		// line internal/php8/scanner.go:13788
+		// line internal/php8/scanner.go:13741
 		switch lex.data[(lex.p)] {
-		case 69:
+		case 72:
 			goto tr534
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
+			goto tr334
+		case 104:
 			goto tr534
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr534:
+		goto tr233
+	tr237:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st342
 	st342:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof342
 		}
 	st_case_342:
-		// line internal/php8/scanner.go:13829
+		// line internal/php8/scanner.go:13782
 		switch lex.data[(lex.p)] {
-		case 83:
+		case 65:
 			goto tr535
+		case 69:
+			goto tr536
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
+			goto tr334
+		case 97:
 			goto tr535
+		case 101:
+			goto tr536
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr535:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st343
 	st343:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof343
 		}
 	st_case_343:
-		// line internal/php8/scanner.go:13870
+		// line internal/php8/scanner.go:13827
 		switch lex.data[(lex.p)] {
-		case 80:
-			goto tr536
+		case 77:
+			goto tr537
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 112:
-			goto tr536
+			goto tr334
+		case 109:
+			goto tr537
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr536:
+		goto tr233
+	tr537:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st344
 	st344:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof344
 		}
 	st_case_344:
-		// line internal/php8/scanner.go:13911
+		// line internal/php8/scanner.go:13868
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr537
+		case 69:
+			goto tr538
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr537
+			goto tr334
+		case 101:
+			goto tr538
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr537:
+		goto tr233
+	tr538:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st345
 	st345:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof345
 		}
 	st_case_345:
-		// line internal/php8/scanner.go:13952
+		// line internal/php8/scanner.go:13909
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr538
+		case 83:
+			goto tr539
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr538
+			goto tr334
+		case 115:
+			goto tr539
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr538:
+		goto tr233
+	tr539:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st346
 	st346:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof346
 		}
 	st_case_346:
-		// line internal/php8/scanner.go:13993
+		// line internal/php8/scanner.go:13950
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr539
+		case 80:
+			goto tr540
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr539
+			goto tr334
+		case 112:
+			goto tr540
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr539:
+		goto tr233
+	tr540:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:249
-		lex.act = 60
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st347
 	st347:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof347
 		}
 	st_case_347:
-		// line internal/php8/scanner.go:14034
+		// line internal/php8/scanner.go:13991
 		switch lex.data[(lex.p)] {
+		case 65:
+			goto tr541
 		case 92:
-			goto st96
+			goto st94
 		case 96:
-			goto tr540
+			goto tr334
+		case 97:
+			goto tr541
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr540
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr540
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr540
+				goto tr334
 			}
 		default:
-			goto tr540
+			goto tr334
 		}
-		goto tr231
-	st96:
+		goto tr233
+	tr541:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st348
+	st348:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof96
+			goto _test_eof348
 		}
-	st_case_96:
+	st_case_348:
+		// line internal/php8/scanner.go:14032
+		switch lex.data[(lex.p)] {
+		case 67:
+			goto tr542
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 99:
+			goto tr542
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr542:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st349
+	st349:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof349
+		}
+	st_case_349:
+		// line internal/php8/scanner.go:14073
+		switch lex.data[(lex.p)] {
+		case 69:
+			goto tr543
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 101:
+			goto tr543
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr543:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:260
+		lex.act = 61
+		goto st350
+	st350:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof350
+		}
+	st_case_350:
+		// line internal/php8/scanner.go:14114
+		switch lex.data[(lex.p)] {
+		case 92:
+			goto st97
+		case 96:
+			goto tr544
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr544
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr544
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr544
+			}
+		default:
+			goto tr544
+		}
+		goto tr233
+	st97:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof97
+		}
+	st_case_97:
 		if lex.data[(lex.p)] == 96 {
 			goto tr12
 		}
@@ -15346,3089 +15449,3041 @@ func (lex *Lexer) Lex() *token.Token {
 		default:
 			goto tr12
 		}
-		goto tr136
-	tr136:
+		goto tr137
+	tr137:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:202
-		lex.act = 14
-		goto st348
-	st348:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof348
-		}
-	st_case_348:
-		// line internal/php8/scanner.go:14092
-		switch lex.data[(lex.p)] {
-		case 92:
-			goto st96
-		case 96:
-			goto tr542
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr542
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr542
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr542
-			}
-		default:
-			goto tr542
-		}
-		goto tr136
-	tr532:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st349
-	st349:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof349
-		}
-	st_case_349:
-		// line internal/php8/scanner.go:14129
-		switch lex.data[(lex.p)] {
-		case 87:
-			goto tr543
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 119:
-			goto tr543
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr236:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st350
-	st350:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof350
-		}
-	st_case_350:
-		// line internal/php8/scanner.go:14170
-		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr544
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 114:
-			goto tr544
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr237:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:213
+		lex.act = 15
 		goto st351
 	st351:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof351
 		}
 	st_case_351:
-		// line internal/php8/scanner.go:14211
+		// line internal/php8/scanner.go:14172
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr545
-		case 85:
-			goto tr546
 		case 92:
-			goto st93
+			goto st97
 		case 96:
-			goto tr330
-		case 114:
-			goto tr545
-		case 117:
 			goto tr546
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr546
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr546
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr546
 			}
 		default:
-			goto tr330
+			goto tr546
 		}
-		goto tr231
-	tr545:
+		goto tr137
+	tr536:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st352
 	st352:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof352
 		}
 	st_case_352:
-		// line internal/php8/scanner.go:14256
+		// line internal/php8/scanner.go:14209
 		switch lex.data[(lex.p)] {
-		case 73:
+		case 87:
 			goto tr547
-		case 79:
-			goto tr548
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
+			goto tr334
+		case 119:
 			goto tr547
-		case 111:
-			goto tr548
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr547:
+		goto tr233
+	tr238:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st353
 	st353:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof353
 		}
 	st_case_353:
-		// line internal/php8/scanner.go:14301
+		// line internal/php8/scanner.go:14250
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr549
-		case 86:
-			goto tr550
+		case 82:
+			goto tr548
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr549
-		case 118:
-			goto tr550
+			goto tr334
+		case 114:
+			goto tr548
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr549:
+		goto tr233
+	tr239:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st354
 	st354:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof354
 		}
 	st_case_354:
-		// line internal/php8/scanner.go:14346
+		// line internal/php8/scanner.go:14291
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr551
+		case 82:
+			goto tr549
+		case 85:
+			goto tr550
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr551
+			goto tr334
+		case 114:
+			goto tr549
+		case 117:
+			goto tr550
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr550:
+		goto tr233
+	tr549:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st355
 	st355:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof355
 		}
 	st_case_355:
-		// line internal/php8/scanner.go:14387
+		// line internal/php8/scanner.go:14336
 		switch lex.data[(lex.p)] {
-		case 65:
+		case 73:
+			goto tr551
+		case 79:
 			goto tr552
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
+			goto tr334
+		case 105:
+			goto tr551
+		case 111:
 			goto tr552
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr552:
+		goto tr233
+	tr551:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st356
 	st356:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof356
 		}
 	st_case_356:
-		// line internal/php8/scanner.go:14428
+		// line internal/php8/scanner.go:14381
 		switch lex.data[(lex.p)] {
-		case 84:
+		case 78:
 			goto tr553
+		case 86:
+			goto tr554
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
+			goto tr334
+		case 110:
 			goto tr553
+		case 118:
+			goto tr554
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr553:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st357
 	st357:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof357
 		}
 	st_case_357:
-		// line internal/php8/scanner.go:14469
+		// line internal/php8/scanner.go:14426
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr554
+		case 84:
+			goto tr555
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr554
+			goto tr334
+		case 116:
+			goto tr555
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr548:
+		goto tr233
+	tr554:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st358
 	st358:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof358
 		}
 	st_case_358:
-		// line internal/php8/scanner.go:14510
+		// line internal/php8/scanner.go:14467
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr555
+		case 65:
+			goto tr556
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr555
+			goto tr334
+		case 97:
+			goto tr556
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr555:
+		goto tr233
+	tr556:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st359
 	st359:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof359
 		}
 	st_case_359:
-		// line internal/php8/scanner.go:14551
+		// line internal/php8/scanner.go:14508
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr556
+		case 84:
+			goto tr557
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr556
+			goto tr334
+		case 116:
+			goto tr557
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr556:
+		goto tr233
+	tr557:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st360
 	st360:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof360
 		}
 	st_case_360:
-		// line internal/php8/scanner.go:14592
+		// line internal/php8/scanner.go:14549
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr557
+		case 69:
+			goto tr558
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr557
+			goto tr334
+		case 101:
+			goto tr558
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr557:
+		goto tr233
+	tr552:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st361
 	st361:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof361
 		}
 	st_case_361:
-		// line internal/php8/scanner.go:14633
+		// line internal/php8/scanner.go:14590
 		switch lex.data[(lex.p)] {
 		case 84:
-			goto tr558
+			goto tr559
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 116:
-			goto tr558
+			goto tr559
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr558:
+		goto tr233
+	tr559:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st362
 	st362:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof362
 		}
 	st_case_362:
-		// line internal/php8/scanner.go:14674
+		// line internal/php8/scanner.go:14631
 		switch lex.data[(lex.p)] {
 		case 69:
-			goto tr559
+			goto tr560
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 101:
-			goto tr559
+			goto tr560
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr559:
+		goto tr233
+	tr560:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st363
 	st363:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof363
 		}
 	st_case_363:
-		// line internal/php8/scanner.go:14715
+		// line internal/php8/scanner.go:14672
 		switch lex.data[(lex.p)] {
-		case 68:
-			goto tr560
+		case 67:
+			goto tr561
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 100:
-			goto tr560
+			goto tr334
+		case 99:
+			goto tr561
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr546:
+		goto tr233
+	tr561:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st364
 	st364:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof364
 		}
 	st_case_364:
-		// line internal/php8/scanner.go:14756
+		// line internal/php8/scanner.go:14713
 		switch lex.data[(lex.p)] {
-		case 66:
-			goto tr561
+		case 84:
+			goto tr562
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 98:
-			goto tr561
+			goto tr334
+		case 116:
+			goto tr562
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr561:
+		goto tr233
+	tr562:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st365
 	st365:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof365
 		}
 	st_case_365:
-		// line internal/php8/scanner.go:14797
+		// line internal/php8/scanner.go:14754
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr562
+		case 69:
+			goto tr563
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr562
+			goto tr334
+		case 101:
+			goto tr563
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr562:
+		goto tr233
+	tr563:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st366
 	st366:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof366
 		}
 	st_case_366:
-		// line internal/php8/scanner.go:14838
+		// line internal/php8/scanner.go:14795
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr563
+		case 68:
+			goto tr564
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr563
+			goto tr334
+		case 100:
+			goto tr564
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr563:
+		goto tr233
+	tr550:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st367
 	st367:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof367
 		}
 	st_case_367:
-		// line internal/php8/scanner.go:14879
+		// line internal/php8/scanner.go:14836
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr564
+		case 66:
+			goto tr565
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr564
+			goto tr334
+		case 98:
+			goto tr565
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr238:
+		goto tr233
+	tr565:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st368
 	st368:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof368
 		}
 	st_case_368:
-		// line internal/php8/scanner.go:14920
+		// line internal/php8/scanner.go:14877
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr565
+		case 76:
+			goto tr566
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr565
+			goto tr334
+		case 108:
+			goto tr566
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr565:
+		goto tr233
+	tr566:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st369
 	st369:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof369
 		}
 	st_case_369:
-		// line internal/php8/scanner.go:14961
+		// line internal/php8/scanner.go:14918
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr566
-		case 81:
+		case 73:
 			goto tr567
-		case 84:
-			goto tr568
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr566
-		case 113:
+			goto tr334
+		case 105:
 			goto tr567
-		case 116:
-			goto tr568
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr566:
+		goto tr233
+	tr567:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st370
 	st370:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof370
 		}
 	st_case_370:
-		// line internal/php8/scanner.go:15010
+		// line internal/php8/scanner.go:14959
 		switch lex.data[(lex.p)] {
-		case 68:
-			goto tr569
+		case 67:
+			goto tr568
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 100:
-			goto tr569
+			goto tr334
+		case 99:
+			goto tr568
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr569:
+		goto tr233
+	tr240:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st371
 	st371:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof371
 		}
 	st_case_371:
-		// line internal/php8/scanner.go:15051
+		// line internal/php8/scanner.go:15000
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr570
+		case 69:
+			goto tr569
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr570
+			goto tr334
+		case 101:
+			goto tr569
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr570:
+		goto tr233
+	tr569:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st372
 	st372:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof372
 		}
 	st_case_372:
-		// line internal/php8/scanner.go:15092
+		// line internal/php8/scanner.go:15041
 		switch lex.data[(lex.p)] {
-		case 78:
+		case 65:
+			goto tr570
+		case 81:
 			goto tr571
+		case 84:
+			goto tr572
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
+			goto tr334
+		case 97:
+			goto tr570
+		case 113:
 			goto tr571
+		case 116:
+			goto tr572
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr571:
+		goto tr233
+	tr570:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st373
 	st373:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof373
 		}
 	st_case_373:
-		// line internal/php8/scanner.go:15133
+		// line internal/php8/scanner.go:15090
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr572
+		case 68:
+			goto tr573
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr572
+			goto tr334
+		case 100:
+			goto tr573
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr572:
+		goto tr233
+	tr573:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st374
 	st374:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof374
 		}
 	st_case_374:
-		// line internal/php8/scanner.go:15174
+		// line internal/php8/scanner.go:15131
 		switch lex.data[(lex.p)] {
-		case 89:
-			goto tr573
+		case 79:
+			goto tr574
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 121:
-			goto tr573
+			goto tr334
+		case 111:
+			goto tr574
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr567:
+		goto tr233
+	tr574:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st375
 	st375:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof375
 		}
 	st_case_375:
-		// line internal/php8/scanner.go:15215
+		// line internal/php8/scanner.go:15172
 		switch lex.data[(lex.p)] {
-		case 85:
-			goto tr574
+		case 78:
+			goto tr575
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 117:
-			goto tr574
+			goto tr334
+		case 110:
+			goto tr575
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr574:
+		goto tr233
+	tr575:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st376
 	st376:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof376
 		}
 	st_case_376:
-		// line internal/php8/scanner.go:15256
+		// line internal/php8/scanner.go:15213
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr575
+		case 76:
+			goto tr576
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr575
+			goto tr334
+		case 108:
+			goto tr576
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr575:
+		goto tr233
+	tr576:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st377
 	st377:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof377
 		}
 	st_case_377:
-		// line internal/php8/scanner.go:15297
+		// line internal/php8/scanner.go:15254
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr576
+		case 89:
+			goto tr577
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr576
+			goto tr334
+		case 121:
+			goto tr577
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr576:
+		goto tr233
+	tr571:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st378
 	st378:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof378
 		}
 	st_case_378:
-		// line internal/php8/scanner.go:15338
+		// line internal/php8/scanner.go:15295
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr577
+		case 85:
+			goto tr578
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr577
+			goto tr334
+		case 117:
+			goto tr578
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr577:
+		goto tr233
+	tr578:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:270
-		lex.act = 81
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st379
 	st379:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof379
 		}
 	st_case_379:
-		// line internal/php8/scanner.go:15379
+		// line internal/php8/scanner.go:15336
 		switch lex.data[(lex.p)] {
+		case 73:
+			goto tr579
 		case 92:
-			goto st93
-		case 95:
+			goto st94
+		case 96:
+			goto tr334
+		case 105:
 			goto tr579
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr578
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr578
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr578
+				goto tr334
 			}
 		default:
-			goto tr578
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr579:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st380
 	st380:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof380
 		}
 	st_case_380:
-		// line internal/php8/scanner.go:15416
+		// line internal/php8/scanner.go:15377
 		switch lex.data[(lex.p)] {
-		case 79:
+		case 82:
 			goto tr580
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
+			goto tr334
+		case 114:
 			goto tr580
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr580:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st381
 	st381:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof381
 		}
 	st_case_381:
-		// line internal/php8/scanner.go:15457
+		// line internal/php8/scanner.go:15418
 		switch lex.data[(lex.p)] {
-		case 78:
+		case 69:
 			goto tr581
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
+			goto tr334
+		case 101:
 			goto tr581
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr581:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:281
+		lex.act = 82
 		goto st382
 	st382:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof382
 		}
 	st_case_382:
-		// line internal/php8/scanner.go:15498
+		// line internal/php8/scanner.go:15459
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr582
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 99:
-			goto tr582
+			goto st94
+		case 95:
+			goto tr583
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr582
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr582
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr582
 			}
 		default:
-			goto tr330
+			goto tr582
 		}
-		goto tr231
-	tr582:
+		goto tr233
+	tr583:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st383
 	st383:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof383
 		}
 	st_case_383:
-		// line internal/php8/scanner.go:15539
+		// line internal/php8/scanner.go:15496
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr583
+		case 79:
+			goto tr584
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr583
+			goto tr334
+		case 111:
+			goto tr584
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr568:
+		goto tr233
+	tr584:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st384
 	st384:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof384
 		}
 	st_case_384:
-		// line internal/php8/scanner.go:15580
+		// line internal/php8/scanner.go:15537
 		switch lex.data[(lex.p)] {
-		case 85:
-			goto tr584
+		case 78:
+			goto tr585
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 117:
-			goto tr584
+			goto tr334
+		case 110:
+			goto tr585
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr584:
+		goto tr233
+	tr585:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st385
 	st385:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof385
 		}
 	st_case_385:
-		// line internal/php8/scanner.go:15621
+		// line internal/php8/scanner.go:15578
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr585
+		case 67:
+			goto tr586
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr585
+			goto tr334
+		case 99:
+			goto tr586
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr585:
+		goto tr233
+	tr586:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st386
 	st386:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof386
 		}
 	st_case_386:
-		// line internal/php8/scanner.go:15662
+		// line internal/php8/scanner.go:15619
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr586
+		case 69:
+			goto tr587
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr586
+			goto tr334
+		case 101:
+			goto tr587
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr239:
+		goto tr233
+	tr572:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st387
 	st387:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof387
 		}
 	st_case_387:
-		// line internal/php8/scanner.go:15703
+		// line internal/php8/scanner.go:15660
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr587
-		case 87:
+		case 85:
 			goto tr588
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr587
-		case 119:
+			goto tr334
+		case 117:
 			goto tr588
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr587:
+		goto tr233
+	tr588:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st388
 	st388:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof388
 		}
 	st_case_388:
-		// line internal/php8/scanner.go:15748
+		// line internal/php8/scanner.go:15701
 		switch lex.data[(lex.p)] {
-		case 65:
+		case 82:
 			goto tr589
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
+			goto tr334
+		case 114:
 			goto tr589
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr589:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st389
 	st389:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof389
 		}
 	st_case_389:
-		// line internal/php8/scanner.go:15789
+		// line internal/php8/scanner.go:15742
 		switch lex.data[(lex.p)] {
-		case 84:
+		case 78:
 			goto tr590
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
+			goto tr334
+		case 110:
 			goto tr590
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr590:
+		goto tr233
+	tr241:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st390
 	st390:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof390
 		}
 	st_case_390:
-		// line internal/php8/scanner.go:15830
+		// line internal/php8/scanner.go:15783
 		switch lex.data[(lex.p)] {
-		case 73:
+		case 84:
 			goto tr591
+		case 87:
+			goto tr592
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
+			goto tr334
+		case 116:
 			goto tr591
+		case 119:
+			goto tr592
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr591:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st391
 	st391:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof391
 		}
 	st_case_391:
-		// line internal/php8/scanner.go:15871
+		// line internal/php8/scanner.go:15828
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr592
+		case 65:
+			goto tr593
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr592
+			goto tr334
+		case 97:
+			goto tr593
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr588:
+		goto tr233
+	tr593:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st392
 	st392:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof392
 		}
 	st_case_392:
-		// line internal/php8/scanner.go:15912
+		// line internal/php8/scanner.go:15869
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr593
+		case 84:
+			goto tr594
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr593
+			goto tr334
+		case 116:
+			goto tr594
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr593:
+		goto tr233
+	tr594:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st393
 	st393:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof393
 		}
 	st_case_393:
-		// line internal/php8/scanner.go:15953
+		// line internal/php8/scanner.go:15910
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr594
+		case 73:
+			goto tr595
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr594
+			goto tr334
+		case 105:
+			goto tr595
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr594:
+		goto tr233
+	tr595:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st394
 	st394:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof394
 		}
 	st_case_394:
-		// line internal/php8/scanner.go:15994
+		// line internal/php8/scanner.go:15951
 		switch lex.data[(lex.p)] {
 		case 67:
-			goto tr595
+			goto tr596
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 99:
-			goto tr595
+			goto tr596
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr595:
+		goto tr233
+	tr592:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st395
 	st395:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof395
 		}
 	st_case_395:
-		// line internal/php8/scanner.go:16035
+		// line internal/php8/scanner.go:15992
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr596
+		case 73:
+			goto tr597
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
-			goto tr596
+			goto tr334
+		case 105:
+			goto tr597
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr240:
+		goto tr233
+	tr597:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st396
 	st396:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof396
 		}
 	st_case_396:
-		// line internal/php8/scanner.go:16076
+		// line internal/php8/scanner.go:16033
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr597
-		case 82:
+		case 84:
 			goto tr598
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
-			goto tr597
-		case 114:
+			goto tr334
+		case 116:
 			goto tr598
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr597:
+		goto tr233
+	tr598:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st397
 	st397:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof397
 		}
 	st_case_397:
-		// line internal/php8/scanner.go:16121
+		// line internal/php8/scanner.go:16074
 		switch lex.data[(lex.p)] {
-		case 82:
+		case 67:
 			goto tr599
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
+			goto tr334
+		case 99:
 			goto tr599
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr599:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st398
 	st398:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof398
 		}
 	st_case_398:
-		// line internal/php8/scanner.go:16162
+		// line internal/php8/scanner.go:16115
 		switch lex.data[(lex.p)] {
-		case 79:
+		case 72:
 			goto tr600
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
+			goto tr334
+		case 104:
 			goto tr600
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr600:
+		goto tr233
+	tr242:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st399
 	st399:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof399
 		}
 	st_case_399:
-		// line internal/php8/scanner.go:16203
+		// line internal/php8/scanner.go:16156
 		switch lex.data[(lex.p)] {
-		case 87:
+		case 72:
 			goto tr601
+		case 82:
+			goto tr602
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 119:
+			goto tr334
+		case 104:
 			goto tr601
+		case 114:
+			goto tr602
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr598:
+		goto tr233
+	tr601:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st400
 	st400:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof400
 		}
 	st_case_400:
-		// line internal/php8/scanner.go:16244
+		// line internal/php8/scanner.go:16201
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr602
-		case 89:
+		case 82:
 			goto tr603
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr602
-		case 121:
+			goto tr334
+		case 114:
 			goto tr603
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr602:
+		goto tr233
+	tr603:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st401
 	st401:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof401
 		}
 	st_case_401:
-		// line internal/php8/scanner.go:16289
+		// line internal/php8/scanner.go:16242
 		switch lex.data[(lex.p)] {
-		case 73:
+		case 79:
 			goto tr604
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
+			goto tr334
+		case 111:
 			goto tr604
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr604:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st402
 	st402:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof402
 		}
 	st_case_402:
-		// line internal/php8/scanner.go:16330
+		// line internal/php8/scanner.go:16283
 		switch lex.data[(lex.p)] {
-		case 84:
+		case 87:
 			goto tr605
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
+			goto tr334
+		case 119:
 			goto tr605
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr241:
+		goto tr233
+	tr602:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st403
 	st403:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof403
 		}
 	st_case_403:
-		// line internal/php8/scanner.go:16371
+		// line internal/php8/scanner.go:16324
 		switch lex.data[(lex.p)] {
-		case 78:
+		case 65:
 			goto tr606
-		case 83:
+		case 89:
 			goto tr607
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
+			goto tr334
+		case 97:
 			goto tr606
-		case 115:
+		case 121:
 			goto tr607
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr606:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st404
 	st404:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof404
 		}
 	st_case_404:
-		// line internal/php8/scanner.go:16416
+		// line internal/php8/scanner.go:16369
 		switch lex.data[(lex.p)] {
-		case 83:
+		case 73:
 			goto tr608
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
+			goto tr334
+		case 105:
 			goto tr608
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr608:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st405
 	st405:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof405
 		}
 	st_case_405:
-		// line internal/php8/scanner.go:16457
+		// line internal/php8/scanner.go:16410
 		switch lex.data[(lex.p)] {
-		case 69:
+		case 84:
 			goto tr609
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
+			goto tr334
+		case 116:
 			goto tr609
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr609:
+		goto tr233
+	tr243:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st406
 	st406:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof406
 		}
 	st_case_406:
-		// line internal/php8/scanner.go:16498
+		// line internal/php8/scanner.go:16451
 		switch lex.data[(lex.p)] {
-		case 84:
+		case 78:
 			goto tr610
+		case 83:
+			goto tr611
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
+			goto tr334
+		case 110:
 			goto tr610
+		case 115:
+			goto tr611
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr607:
+		goto tr233
+	tr610:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st407
 	st407:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof407
 		}
 	st_case_407:
-		// line internal/php8/scanner.go:16539
+		// line internal/php8/scanner.go:16496
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr611
+		case 83:
+			goto tr612
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr611
+			goto tr334
+		case 115:
+			goto tr612
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr242:
+		goto tr233
+	tr612:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st408
 	st408:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof408
 		}
 	st_case_408:
-		// line internal/php8/scanner.go:16580
+		// line internal/php8/scanner.go:16537
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr612
+		case 69:
+			goto tr613
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr612
+			goto tr334
+		case 101:
+			goto tr613
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr612:
+		goto tr233
+	tr613:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st409
 	st409:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof409
 		}
 	st_case_409:
-		// line internal/php8/scanner.go:16621
+		// line internal/php8/scanner.go:16578
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr613
+		case 84:
+			goto tr614
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr613
+			goto tr334
+		case 116:
+			goto tr614
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr243:
+		goto tr233
+	tr611:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st410
 	st410:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof410
 		}
 	st_case_410:
-		// line internal/php8/scanner.go:16662
+		// line internal/php8/scanner.go:16619
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr614
+		case 69:
+			goto tr615
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 104:
-			goto tr614
+			goto tr334
+		case 101:
+			goto tr615
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr614:
+		goto tr233
+	tr244:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st411
 	st411:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof411
 		}
 	st_case_411:
-		// line internal/php8/scanner.go:16703
+		// line internal/php8/scanner.go:16660
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr615
+		case 65:
+			goto tr616
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr615
+			goto tr334
+		case 97:
+			goto tr616
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr615:
+		goto tr233
+	tr616:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st412
 	st412:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof412
 		}
 	st_case_412:
-		// line internal/php8/scanner.go:16744
+		// line internal/php8/scanner.go:16701
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr616
+		case 82:
+			goto tr617
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr616
+			goto tr334
+		case 114:
+			goto tr617
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr616:
+		goto tr233
+	tr245:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st413
 	st413:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof413
 		}
 	st_case_413:
-		// line internal/php8/scanner.go:16785
+		// line internal/php8/scanner.go:16742
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr617
+		case 72:
+			goto tr618
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr617
+			goto tr334
+		case 104:
+			goto tr618
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr244:
+		goto tr233
+	tr618:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st414
 	st414:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof414
 		}
 	st_case_414:
-		// line internal/php8/scanner.go:16826
+		// line internal/php8/scanner.go:16783
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr618
+		case 73:
+			goto tr619
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr618
+			goto tr334
+		case 105:
+			goto tr619
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr618:
+		goto tr233
+	tr619:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st415
 	st415:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof415
 		}
 	st_case_415:
-		// line internal/php8/scanner.go:16867
+		// line internal/php8/scanner.go:16824
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr619
+		case 76:
+			goto tr620
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr619
+			goto tr334
+		case 108:
+			goto tr620
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr245:
+		goto tr233
+	tr620:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st416
 	st416:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof416
 		}
 	st_case_416:
-		// line internal/php8/scanner.go:16908
-		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr620
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 105:
-			goto tr620
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr620:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st417
-	st417:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof417
-		}
-	st_case_417:
-		// line internal/php8/scanner.go:16949
+		// line internal/php8/scanner.go:16865
 		switch lex.data[(lex.p)] {
 		case 69:
 			goto tr621
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 101:
 			goto tr621
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr621:
+		goto tr233
+	tr246:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st417
+	st417:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof417
+		}
+	st_case_417:
+		// line internal/php8/scanner.go:16906
+		switch lex.data[(lex.p)] {
+		case 79:
+			goto tr622
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 111:
+			goto tr622
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr622:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st418
 	st418:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof418
 		}
 	st_case_418:
-		// line internal/php8/scanner.go:16990
+		// line internal/php8/scanner.go:16947
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr622
+		case 82:
+			goto tr623
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr622
+			goto tr334
+		case 114:
+			goto tr623
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr622:
+		goto tr233
+	tr247:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st419
 	st419:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof419
 		}
 	st_case_419:
-		// line internal/php8/scanner.go:17031
+		// line internal/php8/scanner.go:16988
 		switch lex.data[(lex.p)] {
-		case 68:
-			goto tr623
+		case 73:
+			goto tr624
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 100:
-			goto tr623
+			goto tr334
+		case 105:
+			goto tr624
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr623:
+		goto tr233
+	tr624:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:267
-		lex.act = 78
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st420
 	st420:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof420
 		}
 	st_case_420:
-		// line internal/php8/scanner.go:17072
+		// line internal/php8/scanner.go:17029
+		switch lex.data[(lex.p)] {
+		case 69:
+			goto tr625
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 101:
+			goto tr625
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr625:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st421
+	st421:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof421
+		}
+	st_case_421:
+		// line internal/php8/scanner.go:17070
+		switch lex.data[(lex.p)] {
+		case 76:
+			goto tr626
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 108:
+			goto tr626
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr626:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st422
+	st422:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof422
+		}
+	st_case_422:
+		// line internal/php8/scanner.go:17111
+		switch lex.data[(lex.p)] {
+		case 68:
+			goto tr627
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 100:
+			goto tr627
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr627:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:278
+		lex.act = 79
+		goto st423
+	st423:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof423
+		}
+	st_case_423:
+		// line internal/php8/scanner.go:17152
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr139
-		case 13:
 			goto tr140
+		case 13:
+			goto tr141
 		case 32:
-			goto st97
+			goto st98
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr624
+			goto tr628
 		}
 		switch {
 		case lex.data[(lex.p)] < 14:
 			switch {
 			case lex.data[(lex.p)] > 8:
 				if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-					goto st97
+					goto st98
 				}
 			default:
-				goto tr624
+				goto tr628
 			}
 		case lex.data[(lex.p)] > 47:
 			switch {
 			case lex.data[(lex.p)] < 91:
 				if 58 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 64 {
-					goto tr624
+					goto tr628
 				}
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr624
+					goto tr628
 				}
 			default:
-				goto tr624
+				goto tr628
 			}
 		default:
-			goto tr624
+			goto tr628
 		}
-		goto tr231
-	tr142:
-		// line internal/php8/scanner.rl:54
-
-		goto st97
-	st97:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof97
-		}
-	st_case_97:
-		// line internal/php8/scanner.go:17121
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr139
-		case 13:
-			goto tr140
-		case 32:
-			goto st97
-		case 70:
-			goto st100
-		case 102:
-			goto st100
-		}
-		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto st97
-		}
-		goto tr137
-	tr139:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st98
+		goto tr233
 	tr143:
 		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
 
 		goto st98
 	st98:
@@ -18436,23 +18491,23 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof98
 		}
 	st_case_98:
-		// line internal/php8/scanner.go:17169
+		// line internal/php8/scanner.go:17201
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr143
+			goto tr140
 		case 13:
-			goto tr144
+			goto tr141
 		case 32:
-			goto tr142
+			goto st98
 		case 70:
-			goto tr145
+			goto st101
 		case 102:
-			goto tr145
+			goto st101
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr142
+			goto st98
 		}
-		goto tr137
+		goto tr138
 	tr140:
 		// line internal/php8/scanner.rl:38
 
@@ -18484,13 +18539,47 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof99
 		}
 	st_case_99:
-		// line internal/php8/scanner.go:17217
-		if lex.data[(lex.p)] == 10 {
-			goto tr139
+		// line internal/php8/scanner.go:17249
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr144
+		case 13:
+			goto tr145
+		case 32:
+			goto tr143
+		case 70:
+			goto tr146
+		case 102:
+			goto tr146
 		}
-		goto tr137
+		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
+			goto tr143
+		}
+		goto tr138
+	tr141:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st100
 	tr145:
 		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
 
 		goto st100
 	st100:
@@ -18498,2988 +18587,2955 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof100
 		}
 	st_case_100:
-		// line internal/php8/scanner.go:17231
-		switch lex.data[(lex.p)] {
-		case 82:
-			goto st101
-		case 114:
-			goto st101
+		// line internal/php8/scanner.go:17297
+		if lex.data[(lex.p)] == 10 {
+			goto tr140
 		}
-		goto tr137
+		goto tr138
+	tr146:
+		// line internal/php8/scanner.rl:54
+
+		goto st101
 	st101:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof101
 		}
 	st_case_101:
+		// line internal/php8/scanner.go:17311
 		switch lex.data[(lex.p)] {
-		case 79:
+		case 82:
 			goto st102
-		case 111:
+		case 114:
 			goto st102
 		}
-		goto tr137
+		goto tr138
 	st102:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof102
 		}
 	st_case_102:
 		switch lex.data[(lex.p)] {
-		case 77:
-			goto tr148
-		case 109:
-			goto tr148
-		}
-		goto tr137
-	st421:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof421
-		}
-	st_case_421:
-		if lex.data[(lex.p)] == 96 {
-			goto tr625
-		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr625
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr625
-			}
-		default:
-			goto tr625
-		}
-		goto tr150
-	tr150:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st422
-	st422:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof422
-		}
-	st_case_422:
-		// line internal/php8/scanner.go:17294
-		switch lex.data[(lex.p)] {
-		case 92:
+		case 79:
 			goto st103
-		case 96:
-			goto tr626
+		case 111:
+			goto st103
 		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr626
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr626
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr626
-			}
-		default:
-			goto tr626
-		}
-		goto tr150
+		goto tr138
 	st103:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof103
 		}
 	st_case_103:
-		if lex.data[(lex.p)] == 96 {
+		switch lex.data[(lex.p)] {
+		case 77:
+			goto tr149
+		case 109:
 			goto tr149
 		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr149
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr149
-			}
-		default:
-			goto tr149
-		}
-		goto tr150
-	st423:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof423
-		}
-	st_case_423:
-		if lex.data[(lex.p)] == 61 {
-			goto tr628
-		}
-		goto tr260
-	tr248:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st424
+		goto tr138
 	st424:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof424
 		}
 	st_case_424:
-		// line internal/php8/scanner.go:17361
-		switch lex.data[(lex.p)] {
-		case 92:
-			goto st93
-		case 95:
+		if lex.data[(lex.p)] == 96 {
 			goto tr629
 		}
 		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr629
 			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 96:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr629
 			}
 		default:
-			goto tr330
+			goto tr629
 		}
-		goto tr231
-	tr629:
+		goto tr151
+	tr151:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
 		goto st425
 	st425:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof425
 		}
 	st_case_425:
-		// line internal/php8/scanner.go:17398
+		// line internal/php8/scanner.go:17374
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr630
-		case 68:
-			goto tr631
-		case 70:
-			goto tr632
-		case 72:
-			goto tr633
-		case 76:
-			goto tr634
-		case 77:
-			goto tr635
-		case 78:
-			goto tr636
-		case 84:
-			goto tr637
 		case 92:
-			goto st93
+			goto st104
 		case 96:
-			goto tr330
-		case 99:
 			goto tr630
-		case 100:
-			goto tr631
-		case 102:
-			goto tr632
-		case 104:
-			goto tr633
-		case 108:
-			goto tr634
-		case 109:
-			goto tr635
-		case 110:
-			goto tr636
-		case 116:
-			goto tr637
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr630
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr630
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr630
 			}
 		default:
-			goto tr330
+			goto tr630
 		}
-		goto tr231
-	tr630:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st426
+		goto tr151
+	st104:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof104
+		}
+	st_case_104:
+		if lex.data[(lex.p)] == 96 {
+			goto tr150
+		}
+		switch {
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr150
+			}
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr150
+			}
+		default:
+			goto tr150
+		}
+		goto tr151
 	st426:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof426
 		}
 	st_case_426:
-		// line internal/php8/scanner.go:17467
-		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr638
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 108:
-			goto tr638
+		if lex.data[(lex.p)] == 61 {
+			goto tr632
 		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr638:
+		goto tr262
+	tr250:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st427
 	st427:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof427
 		}
 	st_case_427:
-		// line internal/php8/scanner.go:17508
+		// line internal/php8/scanner.go:17441
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr639
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 97:
-			goto tr639
+			goto st94
+		case 95:
+			goto tr633
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr639:
+		goto tr233
+	tr633:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st428
 	st428:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof428
 		}
 	st_case_428:
-		// line internal/php8/scanner.go:17549
+		// line internal/php8/scanner.go:17478
 		switch lex.data[(lex.p)] {
-		case 83:
+		case 67:
+			goto tr634
+		case 68:
+			goto tr635
+		case 70:
+			goto tr636
+		case 72:
+			goto tr637
+		case 76:
+			goto tr638
+		case 77:
+			goto tr639
+		case 78:
 			goto tr640
+		case 84:
+			goto tr641
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
+			goto tr334
+		case 99:
+			goto tr634
+		case 100:
+			goto tr635
+		case 102:
+			goto tr636
+		case 104:
+			goto tr637
+		case 108:
+			goto tr638
+		case 109:
+			goto tr639
+		case 110:
 			goto tr640
+		case 116:
+			goto tr641
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr640:
+		goto tr233
+	tr634:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st429
 	st429:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof429
 		}
 	st_case_429:
-		// line internal/php8/scanner.go:17590
+		// line internal/php8/scanner.go:17547
 		switch lex.data[(lex.p)] {
-		case 83:
-			goto tr641
+		case 76:
+			goto tr642
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
-			goto tr641
+			goto tr334
+		case 108:
+			goto tr642
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr641:
+		goto tr233
+	tr642:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st430
 	st430:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof430
 		}
 	st_case_430:
-		// line internal/php8/scanner.go:17631
+		// line internal/php8/scanner.go:17588
 		switch lex.data[(lex.p)] {
+		case 65:
+			goto tr643
 		case 92:
-			goto st93
-		case 95:
-			goto tr642
+			goto st94
+		case 96:
+			goto tr334
+		case 97:
+			goto tr643
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr642:
+		goto tr233
+	tr643:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st431
 	st431:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof431
 		}
 	st_case_431:
-		// line internal/php8/scanner.go:17668
+		// line internal/php8/scanner.go:17629
 		switch lex.data[(lex.p)] {
+		case 83:
+			goto tr644
 		case 92:
-			goto st93
-		case 95:
-			goto tr643
+			goto st94
+		case 96:
+			goto tr334
+		case 115:
+			goto tr644
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr631:
+		goto tr233
+	tr644:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st432
 	st432:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof432
 		}
 	st_case_432:
-		// line internal/php8/scanner.go:17705
+		// line internal/php8/scanner.go:17670
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr644
+		case 83:
+			goto tr645
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr644
+			goto tr334
+		case 115:
+			goto tr645
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr644:
+		goto tr233
+	tr645:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st433
 	st433:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof433
 		}
 	st_case_433:
-		// line internal/php8/scanner.go:17746
-		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr645
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 114:
-			goto tr645
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr645:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st434
-	st434:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof434
-		}
-	st_case_434:
-		// line internal/php8/scanner.go:17787
+		// line internal/php8/scanner.go:17711
 		switch lex.data[(lex.p)] {
 		case 92:
-			goto st93
+			goto st94
 		case 95:
 			goto tr646
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr646:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st435
-	st435:
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st434
+	st434:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof435
+			goto _test_eof434
 		}
-	st_case_435:
-		// line internal/php8/scanner.go:17824
+	st_case_434:
+		// line internal/php8/scanner.go:17748
 		switch lex.data[(lex.p)] {
 		case 92:
-			goto st93
+			goto st94
 		case 95:
 			goto tr647
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr632:
+		goto tr233
+	tr635:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st435
+	st435:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof435
+		}
+	st_case_435:
+		// line internal/php8/scanner.go:17785
+		switch lex.data[(lex.p)] {
+		case 73:
+			goto tr648
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 105:
+			goto tr648
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr648:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st436
 	st436:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof436
 		}
 	st_case_436:
-		// line internal/php8/scanner.go:17861
+		// line internal/php8/scanner.go:17826
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr648
-		case 85:
+		case 82:
 			goto tr649
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr648
-		case 117:
+			goto tr334
+		case 114:
 			goto tr649
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr648:
+		goto tr233
+	tr649:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st437
 	st437:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof437
 		}
 	st_case_437:
-		// line internal/php8/scanner.go:17906
+		// line internal/php8/scanner.go:17867
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr650
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 108:
+			goto st94
+		case 95:
 			goto tr650
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr650:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st438
 	st438:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof438
 		}
 	st_case_438:
-		// line internal/php8/scanner.go:17947
+		// line internal/php8/scanner.go:17904
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr651
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 101:
+			goto st94
+		case 95:
 			goto tr651
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr651:
+		goto tr233
+	tr636:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st439
 	st439:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof439
 		}
 	st_case_439:
-		// line internal/php8/scanner.go:17988
+		// line internal/php8/scanner.go:17941
 		switch lex.data[(lex.p)] {
-		case 92:
-			goto st93
-		case 95:
+		case 73:
 			goto tr652
+		case 85:
+			goto tr653
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 105:
+			goto tr652
+		case 117:
+			goto tr653
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
+		goto tr233
 	tr652:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st440
 	st440:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof440
 		}
 	st_case_440:
-		// line internal/php8/scanner.go:18025
+		// line internal/php8/scanner.go:17986
 		switch lex.data[(lex.p)] {
+		case 76:
+			goto tr654
 		case 92:
-			goto st93
-		case 95:
-			goto tr653
+			goto st94
+		case 96:
+			goto tr334
+		case 108:
+			goto tr654
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr649:
+		goto tr233
+	tr654:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st441
 	st441:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof441
 		}
 	st_case_441:
-		// line internal/php8/scanner.go:18062
+		// line internal/php8/scanner.go:18027
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr654
+		case 69:
+			goto tr655
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr654
+			goto tr334
+		case 101:
+			goto tr655
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr654:
+		goto tr233
+	tr655:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st442
 	st442:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof442
 		}
 	st_case_442:
-		// line internal/php8/scanner.go:18103
+		// line internal/php8/scanner.go:18068
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr655
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 99:
-			goto tr655
+			goto st94
+		case 95:
+			goto tr656
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr655:
+		goto tr233
+	tr656:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st443
 	st443:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof443
 		}
 	st_case_443:
-		// line internal/php8/scanner.go:18144
+		// line internal/php8/scanner.go:18105
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr656
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 116:
-			goto tr656
+			goto st94
+		case 95:
+			goto tr657
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr656:
+		goto tr233
+	tr653:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st444
 	st444:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof444
 		}
 	st_case_444:
-		// line internal/php8/scanner.go:18185
+		// line internal/php8/scanner.go:18142
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr657
+		case 78:
+			goto tr658
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr657
+			goto tr334
+		case 110:
+			goto tr658
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr657:
+		goto tr233
+	tr658:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st445
 	st445:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof445
 		}
 	st_case_445:
-		// line internal/php8/scanner.go:18226
+		// line internal/php8/scanner.go:18183
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr658
+		case 67:
+			goto tr659
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr658
+			goto tr334
+		case 99:
+			goto tr659
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr658:
+		goto tr233
+	tr659:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st446
 	st446:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof446
 		}
 	st_case_446:
-		// line internal/php8/scanner.go:18267
+		// line internal/php8/scanner.go:18224
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr659
+		case 84:
+			goto tr660
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr659
+			goto tr334
+		case 116:
+			goto tr660
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr659:
+		goto tr233
+	tr660:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st447
 	st447:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof447
 		}
 	st_case_447:
-		// line internal/php8/scanner.go:18308
+		// line internal/php8/scanner.go:18265
 		switch lex.data[(lex.p)] {
+		case 73:
+			goto tr661
 		case 92:
-			goto st93
-		case 95:
-			goto tr660
+			goto st94
+		case 96:
+			goto tr334
+		case 105:
+			goto tr661
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr660:
+		goto tr233
+	tr661:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st448
 	st448:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof448
 		}
 	st_case_448:
-		// line internal/php8/scanner.go:18345
+		// line internal/php8/scanner.go:18306
 		switch lex.data[(lex.p)] {
+		case 79:
+			goto tr662
 		case 92:
-			goto st93
-		case 95:
-			goto tr661
+			goto st94
+		case 96:
+			goto tr334
+		case 111:
+			goto tr662
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr633:
+		goto tr233
+	tr662:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st449
 	st449:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof449
 		}
 	st_case_449:
-		// line internal/php8/scanner.go:18382
+		// line internal/php8/scanner.go:18347
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr662
+		case 78:
+			goto tr663
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr662
+			goto tr334
+		case 110:
+			goto tr663
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr662:
+		goto tr233
+	tr663:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st450
 	st450:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof450
 		}
 	st_case_450:
-		// line internal/php8/scanner.go:18423
+		// line internal/php8/scanner.go:18388
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr663
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 108:
-			goto tr663
+			goto st94
+		case 95:
+			goto tr664
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr663:
+		goto tr233
+	tr664:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st451
 	st451:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof451
 		}
 	st_case_451:
-		// line internal/php8/scanner.go:18464
-		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr664
-		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 116:
-			goto tr664
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	tr664:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
-		goto st452
-	st452:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof452
-		}
-	st_case_452:
-		// line internal/php8/scanner.go:18505
+		// line internal/php8/scanner.go:18425
 		switch lex.data[(lex.p)] {
 		case 92:
-			goto st93
+			goto st94
 		case 95:
 			goto tr665
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr665:
+		goto tr233
+	tr637:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st452
+	st452:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof452
+		}
+	st_case_452:
+		// line internal/php8/scanner.go:18462
+		switch lex.data[(lex.p)] {
+		case 65:
+			goto tr666
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 97:
+			goto tr666
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr666:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st453
 	st453:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof453
 		}
 	st_case_453:
-		// line internal/php8/scanner.go:18542
+		// line internal/php8/scanner.go:18503
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr666
+		case 76:
+			goto tr667
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr666
+			goto tr334
+		case 108:
+			goto tr667
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr666:
+		goto tr233
+	tr667:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st454
 	st454:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof454
 		}
 	st_case_454:
-		// line internal/php8/scanner.go:18583
+		// line internal/php8/scanner.go:18544
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr667
+		case 84:
+			goto tr668
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr667
+			goto tr334
+		case 116:
+			goto tr668
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr667:
+		goto tr233
+	tr668:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st455
 	st455:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof455
 		}
 	st_case_455:
-		// line internal/php8/scanner.go:18624
+		// line internal/php8/scanner.go:18585
 		switch lex.data[(lex.p)] {
-		case 77:
-			goto tr668
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 109:
-			goto tr668
+			goto st94
+		case 95:
+			goto tr669
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr668:
+		goto tr233
+	tr669:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st456
 	st456:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof456
 		}
 	st_case_456:
-		// line internal/php8/scanner.go:18665
+		// line internal/php8/scanner.go:18622
 		switch lex.data[(lex.p)] {
-		case 80:
-			goto tr669
+		case 67:
+			goto tr670
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 112:
-			goto tr669
+			goto tr334
+		case 99:
+			goto tr670
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr669:
+		goto tr233
+	tr670:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st457
 	st457:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof457
 		}
 	st_case_457:
-		// line internal/php8/scanner.go:18706
+		// line internal/php8/scanner.go:18663
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr670
+		case 79:
+			goto tr671
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr670
+			goto tr334
+		case 111:
+			goto tr671
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr670:
+		goto tr233
+	tr671:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st458
 	st458:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof458
 		}
 	st_case_458:
-		// line internal/php8/scanner.go:18747
+		// line internal/php8/scanner.go:18704
 		switch lex.data[(lex.p)] {
-		case 76:
-			goto tr671
+		case 77:
+			goto tr672
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 108:
-			goto tr671
+			goto tr334
+		case 109:
+			goto tr672
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr671:
+		goto tr233
+	tr672:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st459
 	st459:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof459
 		}
 	st_case_459:
-		// line internal/php8/scanner.go:18788
+		// line internal/php8/scanner.go:18745
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr672
+		case 80:
+			goto tr673
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr672
+			goto tr334
+		case 112:
+			goto tr673
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr672:
+		goto tr233
+	tr673:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st460
 	st460:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof460
 		}
 	st_case_460:
-		// line internal/php8/scanner.go:18829
+		// line internal/php8/scanner.go:18786
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr673
+		case 73:
+			goto tr674
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr673
+			goto tr334
+		case 105:
+			goto tr674
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr634:
+		goto tr233
+	tr674:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st461
 	st461:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof461
 		}
 	st_case_461:
-		// line internal/php8/scanner.go:18870
+		// line internal/php8/scanner.go:18827
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr674
+		case 76:
+			goto tr675
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 105:
-			goto tr674
+			goto tr334
+		case 108:
+			goto tr675
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr674:
+		goto tr233
+	tr675:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st462
 	st462:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof462
 		}
 	st_case_462:
-		// line internal/php8/scanner.go:18911
+		// line internal/php8/scanner.go:18868
 		switch lex.data[(lex.p)] {
-		case 78:
-			goto tr675
+		case 69:
+			goto tr676
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 110:
-			goto tr675
+			goto tr334
+		case 101:
+			goto tr676
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr675:
+		goto tr233
+	tr676:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st463
 	st463:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof463
 		}
 	st_case_463:
-		// line internal/php8/scanner.go:18952
+		// line internal/php8/scanner.go:18909
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr676
+		case 82:
+			goto tr677
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr676
+			goto tr334
+		case 114:
+			goto tr677
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr676:
+		goto tr233
+	tr638:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st464
 	st464:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof464
 		}
 	st_case_464:
-		// line internal/php8/scanner.go:18993
+		// line internal/php8/scanner.go:18950
 		switch lex.data[(lex.p)] {
+		case 73:
+			goto tr678
 		case 92:
-			goto st93
-		case 95:
-			goto tr677
+			goto st94
+		case 96:
+			goto tr334
+		case 105:
+			goto tr678
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr677:
+		goto tr233
+	tr678:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st465
 	st465:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof465
 		}
 	st_case_465:
-		// line internal/php8/scanner.go:19030
+		// line internal/php8/scanner.go:18991
 		switch lex.data[(lex.p)] {
+		case 78:
+			goto tr679
 		case 92:
-			goto st93
-		case 95:
-			goto tr678
+			goto st94
+		case 96:
+			goto tr334
+		case 110:
+			goto tr679
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr635:
+		goto tr233
+	tr679:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st466
 	st466:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof466
 		}
 	st_case_466:
-		// line internal/php8/scanner.go:19067
+		// line internal/php8/scanner.go:19032
 		switch lex.data[(lex.p)] {
 		case 69:
-			goto tr679
+			goto tr680
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
+			goto tr334
 		case 101:
-			goto tr679
+			goto tr680
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr679:
+		goto tr233
+	tr680:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st467
 	st467:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof467
 		}
 	st_case_467:
-		// line internal/php8/scanner.go:19108
+		// line internal/php8/scanner.go:19073
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr680
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 116:
-			goto tr680
+			goto st94
+		case 95:
+			goto tr681
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr680:
+		goto tr233
+	tr681:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st468
 	st468:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof468
 		}
 	st_case_468:
-		// line internal/php8/scanner.go:19149
+		// line internal/php8/scanner.go:19110
 		switch lex.data[(lex.p)] {
-		case 72:
-			goto tr681
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 104:
-			goto tr681
+			goto st94
+		case 95:
+			goto tr682
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr681:
+		goto tr233
+	tr639:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st469
 	st469:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof469
 		}
 	st_case_469:
-		// line internal/php8/scanner.go:19190
+		// line internal/php8/scanner.go:19147
 		switch lex.data[(lex.p)] {
-		case 79:
-			goto tr682
+		case 69:
+			goto tr683
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 111:
-			goto tr682
+			goto tr334
+		case 101:
+			goto tr683
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr682:
+		goto tr233
+	tr683:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st470
 	st470:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof470
 		}
 	st_case_470:
-		// line internal/php8/scanner.go:19231
+		// line internal/php8/scanner.go:19188
 		switch lex.data[(lex.p)] {
-		case 68:
-			goto tr683
+		case 84:
+			goto tr684
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 100:
-			goto tr683
+			goto tr334
+		case 116:
+			goto tr684
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr683:
+		goto tr233
+	tr684:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st471
 	st471:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof471
 		}
 	st_case_471:
-		// line internal/php8/scanner.go:19272
+		// line internal/php8/scanner.go:19229
 		switch lex.data[(lex.p)] {
+		case 72:
+			goto tr685
 		case 92:
-			goto st93
-		case 95:
-			goto tr684
+			goto st94
+		case 96:
+			goto tr334
+		case 104:
+			goto tr685
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr684:
+		goto tr233
+	tr685:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st472
 	st472:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof472
 		}
 	st_case_472:
-		// line internal/php8/scanner.go:19309
+		// line internal/php8/scanner.go:19270
 		switch lex.data[(lex.p)] {
+		case 79:
+			goto tr686
 		case 92:
-			goto st93
-		case 95:
-			goto tr685
+			goto st94
+		case 96:
+			goto tr334
+		case 111:
+			goto tr686
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr636:
+		goto tr233
+	tr686:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st473
 	st473:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof473
 		}
 	st_case_473:
-		// line internal/php8/scanner.go:19346
+		// line internal/php8/scanner.go:19311
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr686
+		case 68:
+			goto tr687
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr686
+			goto tr334
+		case 100:
+			goto tr687
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr686:
+		goto tr233
+	tr687:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st474
 	st474:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof474
 		}
 	st_case_474:
-		// line internal/php8/scanner.go:19387
+		// line internal/php8/scanner.go:19352
 		switch lex.data[(lex.p)] {
-		case 77:
-			goto tr687
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 109:
-			goto tr687
+			goto st94
+		case 95:
+			goto tr688
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr687:
+		goto tr233
+	tr688:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st475
 	st475:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof475
 		}
 	st_case_475:
-		// line internal/php8/scanner.go:19428
+		// line internal/php8/scanner.go:19389
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr688
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 101:
-			goto tr688
+			goto st94
+		case 95:
+			goto tr689
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr688:
+		goto tr233
+	tr640:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st476
 	st476:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof476
 		}
 	st_case_476:
-		// line internal/php8/scanner.go:19469
+		// line internal/php8/scanner.go:19426
 		switch lex.data[(lex.p)] {
-		case 83:
-			goto tr689
+		case 65:
+			goto tr690
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 115:
-			goto tr689
+			goto tr334
+		case 97:
+			goto tr690
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr689:
+		goto tr233
+	tr690:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st477
 	st477:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof477
 		}
 	st_case_477:
-		// line internal/php8/scanner.go:19510
+		// line internal/php8/scanner.go:19467
 		switch lex.data[(lex.p)] {
-		case 80:
-			goto tr690
+		case 77:
+			goto tr691
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 112:
-			goto tr690
+			goto tr334
+		case 109:
+			goto tr691
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr690:
+		goto tr233
+	tr691:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st478
 	st478:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof478
 		}
 	st_case_478:
-		// line internal/php8/scanner.go:19551
+		// line internal/php8/scanner.go:19508
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr691
+		case 69:
+			goto tr692
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 97:
-			goto tr691
+			goto tr334
+		case 101:
+			goto tr692
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr691:
+		goto tr233
+	tr692:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st479
 	st479:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof479
 		}
 	st_case_479:
-		// line internal/php8/scanner.go:19592
+		// line internal/php8/scanner.go:19549
 		switch lex.data[(lex.p)] {
-		case 67:
-			goto tr692
+		case 83:
+			goto tr693
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 99:
-			goto tr692
+			goto tr334
+		case 115:
+			goto tr693
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr692:
+		goto tr233
+	tr693:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st480
 	st480:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof480
 		}
 	st_case_480:
-		// line internal/php8/scanner.go:19633
+		// line internal/php8/scanner.go:19590
 		switch lex.data[(lex.p)] {
-		case 69:
-			goto tr693
+		case 80:
+			goto tr694
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 101:
-			goto tr693
+			goto tr334
+		case 112:
+			goto tr694
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr693:
+		goto tr233
+	tr694:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st481
 	st481:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof481
 		}
 	st_case_481:
-		// line internal/php8/scanner.go:19674
+		// line internal/php8/scanner.go:19631
 		switch lex.data[(lex.p)] {
+		case 65:
+			goto tr695
 		case 92:
-			goto st93
-		case 95:
-			goto tr694
+			goto st94
+		case 96:
+			goto tr334
+		case 97:
+			goto tr695
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr694:
+		goto tr233
+	tr695:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st482
 	st482:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof482
 		}
 	st_case_482:
-		// line internal/php8/scanner.go:19711
+		// line internal/php8/scanner.go:19672
 		switch lex.data[(lex.p)] {
+		case 67:
+			goto tr696
 		case 92:
-			goto st93
-		case 95:
-			goto tr695
+			goto st94
+		case 96:
+			goto tr334
+		case 99:
+			goto tr696
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr637:
+		goto tr233
+	tr696:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st483
 	st483:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof483
 		}
 	st_case_483:
-		// line internal/php8/scanner.go:19748
+		// line internal/php8/scanner.go:19713
 		switch lex.data[(lex.p)] {
-		case 82:
-			goto tr696
+		case 69:
+			goto tr697
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 114:
-			goto tr696
+			goto tr334
+		case 101:
+			goto tr697
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr696:
+		goto tr233
+	tr697:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st484
 	st484:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof484
 		}
 	st_case_484:
-		// line internal/php8/scanner.go:19789
+		// line internal/php8/scanner.go:19754
 		switch lex.data[(lex.p)] {
-		case 65:
-			goto tr697
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 97:
-			goto tr697
+			goto st94
+		case 95:
+			goto tr698
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr697:
+		goto tr233
+	tr698:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st485
 	st485:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof485
 		}
 	st_case_485:
-		// line internal/php8/scanner.go:19830
+		// line internal/php8/scanner.go:19791
 		switch lex.data[(lex.p)] {
-		case 73:
-			goto tr698
 		case 92:
-			goto st93
-		case 96:
-			goto tr330
-		case 105:
-			goto tr698
+			goto st94
+		case 95:
+			goto tr699
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 94:
+			case lex.data[(lex.p)] > 96:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr698:
+		goto tr233
+	tr641:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st486
 	st486:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof486
 		}
 	st_case_486:
-		// line internal/php8/scanner.go:19871
+		// line internal/php8/scanner.go:19828
 		switch lex.data[(lex.p)] {
-		case 84:
-			goto tr699
+		case 82:
+			goto tr700
 		case 92:
-			goto st93
+			goto st94
 		case 96:
-			goto tr330
-		case 116:
-			goto tr699
+			goto tr334
+		case 114:
+			goto tr700
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr699:
+		goto tr233
+	tr700:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st487
 	st487:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof487
 		}
 	st_case_487:
-		// line internal/php8/scanner.go:19912
+		// line internal/php8/scanner.go:19869
 		switch lex.data[(lex.p)] {
+		case 65:
+			goto tr701
 		case 92:
-			goto st93
-		case 95:
-			goto tr700
+			goto st94
+		case 96:
+			goto tr334
+		case 97:
+			goto tr701
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
-			case lex.data[(lex.p)] > 96:
+			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr330
+				goto tr334
 			}
 		default:
-			goto tr330
+			goto tr334
 		}
-		goto tr231
-	tr700:
+		goto tr233
+	tr701:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:356
-		lex.act = 143
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st488
 	st488:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof488
 		}
 	st_case_488:
-		// line internal/php8/scanner.go:19949
+		// line internal/php8/scanner.go:19910
 		switch lex.data[(lex.p)] {
+		case 73:
+			goto tr702
 		case 92:
-			goto st93
-		case 95:
-			goto tr701
+			goto st94
+		case 96:
+			goto tr334
+		case 105:
+			goto tr702
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr330
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 96:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr330
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr330
-			}
-		default:
-			goto tr330
-		}
-		goto tr231
-	st489:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof489
-		}
-	st_case_489:
-		switch lex.data[(lex.p)] {
-		case 61:
-			goto tr702
-		case 124:
-			goto tr703
-		}
-		goto tr260
-	tr151:
-		// line internal/php8/scanner.rl:391
-		(lex.p) = (lex.te) - 1
-		{
-			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
-		}
-		goto st490
-	tr153:
-		// line internal/php8/scanner.rl:395
-		(lex.p) = (lex.te) - 1
-		{
-			lex.ungetCnt(1)
-			{
-				goto st131
-			}
-		}
-		goto st490
-	tr154:
-		// line internal/php8/scanner.rl:393
-		lex.te = (lex.p) + 1
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_NULLSAFE_OBJECT_OPERATOR
-			{
-				(lex.p)++
-				lex.cs = 490
-				goto _out
-			}
-		}
-		goto st490
-	tr704:
-		// line internal/php8/scanner.rl:395
-		lex.te = (lex.p) + 1
-		{
-			lex.ungetCnt(1)
-			{
-				goto st131
-			}
-		}
-		goto st490
-	tr710:
-		// line internal/php8/scanner.rl:391
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
-		}
-		goto st490
-	tr712:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:391
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
-		}
-		goto st490
-	tr716:
-		// line internal/php8/scanner.rl:395
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.ungetCnt(1)
-			{
-				goto st131
-			}
-		}
-		goto st490
-	tr717:
-		// line internal/php8/scanner.rl:392
-		lex.te = (lex.p) + 1
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_OBJECT_OPERATOR
-			{
-				(lex.p)++
-				lex.cs = 490
-				goto _out
-			}
-		}
-		goto st490
-	tr719:
-		lex.cs = 490
-		// line internal/php8/scanner.rl:394
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_STRING
-			lex.cs = 131
-			{
-				(lex.p)++
-				goto _out
-			}
-		}
-		goto _again
-	st490:
-		// line NONE:1
-		lex.ts = 0
-
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof490
-		}
-	st_case_490:
-		// line NONE:1
-		lex.ts = (lex.p)
-
-		// line internal/php8/scanner.go:20049
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr152
-		case 13:
-			goto tr706
-		case 32:
-			goto tr705
-		case 45:
-			goto st494
-		case 63:
-			goto tr708
-		case 96:
-			goto tr704
-		}
-		switch {
-		case lex.data[(lex.p)] < 14:
-			switch {
-			case lex.data[(lex.p)] > 8:
-				if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-					goto tr705
-				}
-			default:
-				goto tr704
+				goto tr334
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr704
+					goto tr334
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr704
+				goto tr334
 			}
 		default:
+			goto tr334
+		}
+		goto tr233
+	tr702:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st489
+	st489:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof489
+		}
+	st_case_489:
+		// line internal/php8/scanner.go:19951
+		switch lex.data[(lex.p)] {
+		case 84:
+			goto tr703
+		case 92:
+			goto st94
+		case 96:
+			goto tr334
+		case 116:
+			goto tr703
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr703:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
+		goto st490
+	st490:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof490
+		}
+	st_case_490:
+		// line internal/php8/scanner.go:19992
+		switch lex.data[(lex.p)] {
+		case 92:
+			goto st94
+		case 95:
 			goto tr704
 		}
-		goto st496
-	tr705:
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 96:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
+		}
+		goto tr233
+	tr704:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		goto st491
-	tr713:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:54
-
+		// line internal/php8/scanner.rl:367
+		lex.act = 144
 		goto st491
 	st491:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof491
 		}
 	st_case_491:
-		// line internal/php8/scanner.go:20104
+		// line internal/php8/scanner.go:20029
 		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr152
-		case 13:
-			goto tr711
-		case 32:
+		case 92:
+			goto st94
+		case 95:
 			goto tr705
 		}
-		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr705
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr334
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 96:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr334
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr334
+			}
+		default:
+			goto tr334
 		}
-		goto tr710
-	tr152:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st492
-	tr714:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st492
+		goto tr233
 	st492:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof492
 		}
 	st_case_492:
-		// line internal/php8/scanner.go:20154
+		switch lex.data[(lex.p)] {
+		case 61:
+			goto tr706
+		case 124:
+			goto tr707
+		}
+		goto tr262
+	tr152:
+		// line internal/php8/scanner.rl:402
+		(lex.p) = (lex.te) - 1
+		{
+			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
+		}
+		goto st493
+	tr154:
+		// line internal/php8/scanner.rl:406
+		(lex.p) = (lex.te) - 1
+		{
+			lex.ungetCnt(1)
+			{
+				goto st133
+			}
+		}
+		goto st493
+	tr155:
+		// line internal/php8/scanner.rl:404
+		lex.te = (lex.p) + 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_NULLSAFE_OBJECT_OPERATOR
+			{
+				(lex.p)++
+				lex.cs = 493
+				goto _out
+			}
+		}
+		goto st493
+	tr708:
+		// line internal/php8/scanner.rl:406
+		lex.te = (lex.p) + 1
+		{
+			lex.ungetCnt(1)
+			{
+				goto st133
+			}
+		}
+		goto st493
+	tr714:
+		// line internal/php8/scanner.rl:402
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
+		}
+		goto st493
+	tr716:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:402
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
+		}
+		goto st493
+	tr720:
+		// line internal/php8/scanner.rl:406
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.ungetCnt(1)
+			{
+				goto st133
+			}
+		}
+		goto st493
+	tr721:
+		// line internal/php8/scanner.rl:403
+		lex.te = (lex.p) + 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_OBJECT_OPERATOR
+			{
+				(lex.p)++
+				lex.cs = 493
+				goto _out
+			}
+		}
+		goto st493
+	tr723:
+		lex.cs = 493
+		// line internal/php8/scanner.rl:405
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_STRING
+			lex.cs = 133
+			{
+				(lex.p)++
+				goto _out
+			}
+		}
+		goto _again
+	st493:
+		// line NONE:1
+		lex.ts = 0
+
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof493
+		}
+	st_case_493:
+		// line NONE:1
+		lex.ts = (lex.p)
+
+		// line internal/php8/scanner.go:20129
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr714
+			goto tr153
+		case 13:
+			goto tr710
+		case 32:
+			goto tr709
+		case 45:
+			goto st497
+		case 63:
+			goto tr712
+		case 96:
+			goto tr708
+		}
+		switch {
+		case lex.data[(lex.p)] < 14:
+			switch {
+			case lex.data[(lex.p)] > 8:
+				if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
+					goto tr709
+				}
+			default:
+				goto tr708
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr708
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr708
+			}
+		default:
+			goto tr708
+		}
+		goto st499
+	tr709:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st494
+	tr717:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:54
+
+		goto st494
+	st494:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof494
+		}
+	st_case_494:
+		// line internal/php8/scanner.go:20184
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr153
 		case 13:
 			goto tr715
 		case 32:
-			goto tr713
+			goto tr709
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr713
+			goto tr709
 		}
-		goto tr712
-	tr711:
+		goto tr714
+	tr153:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -21490,8 +21546,11 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st104
-	tr715:
+		goto st495
+	tr718:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
 		// line internal/php8/scanner.rl:54
 
 		// line internal/php8/scanner.rl:38
@@ -21503,52 +21562,6 @@ func (lex *Lexer) Lex() *token.Token {
 		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
 			lex.newLines.Append(lex.p + 1)
 		}
-
-		goto st104
-	st104:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof104
-		}
-	st_case_104:
-		// line internal/php8/scanner.go:20198
-		if lex.data[(lex.p)] == 10 {
-			goto tr152
-		}
-		goto tr151
-	tr706:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st493
-	st493:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof493
-		}
-	st_case_493:
-		// line internal/php8/scanner.go:20220
-		if lex.data[(lex.p)] == 10 {
-			goto tr152
-		}
-		goto tr716
-	st494:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof494
-		}
-	st_case_494:
-		if lex.data[(lex.p)] == 62 {
-			goto tr717
-		}
-		goto tr716
-	tr708:
-		// line NONE:1
-		lex.te = (lex.p) + 1
 
 		goto st495
 	st495:
@@ -21556,48 +21569,138 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof495
 		}
 	st_case_495:
-		// line internal/php8/scanner.go:20244
-		if lex.data[(lex.p)] == 45 {
-			goto st105
+		// line internal/php8/scanner.go:20234
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr718
+		case 13:
+			goto tr719
+		case 32:
+			goto tr717
+		}
+		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
+			goto tr717
 		}
 		goto tr716
+	tr715:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st105
+	tr719:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st105
 	st105:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof105
 		}
 	st_case_105:
-		if lex.data[(lex.p)] == 62 {
-			goto tr154
+		// line internal/php8/scanner.go:20278
+		if lex.data[(lex.p)] == 10 {
+			goto tr153
 		}
-		goto tr153
+		goto tr152
+	tr710:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st496
 	st496:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof496
 		}
 	st_case_496:
+		// line internal/php8/scanner.go:20300
+		if lex.data[(lex.p)] == 10 {
+			goto tr153
+		}
+		goto tr720
+	st497:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof497
+		}
+	st_case_497:
+		if lex.data[(lex.p)] == 62 {
+			goto tr721
+		}
+		goto tr720
+	tr712:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st498
+	st498:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof498
+		}
+	st_case_498:
+		// line internal/php8/scanner.go:20324
+		if lex.data[(lex.p)] == 45 {
+			goto st106
+		}
+		goto tr720
+	st106:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof106
+		}
+	st_case_106:
+		if lex.data[(lex.p)] == 62 {
+			goto tr155
+		}
+		goto tr154
+	st499:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof499
+		}
+	st_case_499:
 		if lex.data[(lex.p)] == 96 {
-			goto tr719
+			goto tr723
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr719
+				goto tr723
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr719
+					goto tr723
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr719
+				goto tr723
 			}
 		default:
-			goto tr719
+			goto tr723
 		}
-		goto st496
-	tr723:
-		lex.cs = 497
+		goto st499
+	tr727:
+		lex.cs = 500
 		// line NONE:1
 		switch lex.act {
 		case 0:
@@ -21606,13 +21709,13 @@ func (lex *Lexer) Lex() *token.Token {
 					goto st0
 				}
 			}
-		case 156:
+		case 157:
 			{
 				(lex.p) = (lex.te) - 1
 
 				lex.setTokenPosition(tkn)
 				tok = token.T_ENCAPSED_AND_WHITESPACE
-				lex.cs = 520
+				lex.cs = 523
 				{
 					(lex.p)++
 					goto _out
@@ -21621,39 +21724,39 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 
 		goto _again
-	tr724:
-		lex.cs = 497
+	tr728:
+		lex.cs = 500
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:399
+		// line internal/php8/scanner.rl:410
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_ENCAPSED_AND_WHITESPACE
-			lex.cs = 520
+			lex.cs = 523
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr728:
-		lex.cs = 497
-		// line internal/php8/scanner.rl:399
+	tr732:
+		lex.cs = 500
+		// line internal/php8/scanner.rl:410
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_ENCAPSED_AND_WHITESPACE
-			lex.cs = 520
+			lex.cs = 523
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	st497:
+	st500:
 		// line NONE:1
 		lex.ts = 0
 
@@ -21661,13 +21764,13 @@ func (lex *Lexer) Lex() *token.Token {
 		lex.act = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof497
+			goto _test_eof500
 		}
-	st_case_497:
+	st_case_500:
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:20341
+		// line internal/php8/scanner.go:20421
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -21708,119 +21811,39 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1034:
-			goto tr721
+			goto tr725
 		case 1037:
-			goto tr722
+			goto tr726
 		}
 		if 1024 <= _widec && _widec <= 1279 {
-			goto tr720
+			goto tr724
 		}
 		goto st0
 	st_case_0:
 	st0:
 		lex.cs = 0
 		goto _out
-	tr720:
+	tr724:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:399
-		lex.act = 156
-		goto st498
-	tr725:
+		// line internal/php8/scanner.rl:410
+		lex.act = 157
+		goto st501
+	tr729:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:399
-		lex.act = 156
-		goto st498
-	st498:
+		// line internal/php8/scanner.rl:410
+		lex.act = 157
+		goto st501
+	st501:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof498
+			goto _test_eof501
 		}
-	st_case_498:
-		// line internal/php8/scanner.go:20415
-		_widec = int16(lex.data[(lex.p)])
-		switch {
-		case lex.data[(lex.p)] < 11:
-			switch {
-			case lex.data[(lex.p)] > 9:
-				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
-					_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotHeredocEnd(lex.p) {
-						_widec += 256
-					}
-				}
-			default:
-				_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotHeredocEnd(lex.p) {
-					_widec += 256
-				}
-			}
-		case lex.data[(lex.p)] > 12:
-			switch {
-			case lex.data[(lex.p)] > 13:
-				if 14 <= lex.data[(lex.p)] {
-					_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotHeredocEnd(lex.p) {
-						_widec += 256
-					}
-				}
-			case lex.data[(lex.p)] >= 13:
-				_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotHeredocEnd(lex.p) {
-					_widec += 256
-				}
-			}
-		default:
-			_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
-			if lex.isNotHeredocEnd(lex.p) {
-				_widec += 256
-			}
-		}
-		switch _widec {
-		case 1034:
-			goto tr721
-		case 1037:
-			goto tr722
-		}
-		if 1024 <= _widec && _widec <= 1279 {
-			goto tr720
-		}
-		goto tr723
-	tr721:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st499
-	tr726:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st499
-	st499:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof499
-		}
-	st_case_499:
+	st_case_501:
 		// line internal/php8/scanner.go:20495
 		_widec = int16(lex.data[(lex.p)])
 		switch {
@@ -21862,15 +21885,15 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1034:
-			goto tr726
+			goto tr725
 		case 1037:
-			goto tr727
+			goto tr726
 		}
 		if 1024 <= _widec && _widec <= 1279 {
-			goto tr725
+			goto tr724
 		}
-		goto tr724
-	tr722:
+		goto tr727
+	tr725:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -21881,8 +21904,8 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st500
-	tr727:
+		goto st502
+	tr730:
 		// line internal/php8/scanner.rl:54
 
 		// line internal/php8/scanner.rl:38
@@ -21895,12 +21918,12 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st500
-	st500:
+		goto st502
+	st502:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof500
+			goto _test_eof502
 		}
-	st_case_500:
+	st_case_502:
 		// line internal/php8/scanner.go:20575
 		_widec = int16(lex.data[(lex.p)])
 		switch {
@@ -21942,27 +21965,107 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1034:
-			goto tr721
+			goto tr730
 		case 1037:
-			goto tr722
+			goto tr731
 		}
 		if 1024 <= _widec && _widec <= 1279 {
-			goto tr720
+			goto tr729
 		}
 		goto tr728
-	tr155:
-		// line internal/php8/scanner.rl:408
+	tr726:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st503
+	tr731:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st503
+	st503:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof503
+		}
+	st_case_503:
+		// line internal/php8/scanner.go:20655
+		_widec = int16(lex.data[(lex.p)])
+		switch {
+		case lex.data[(lex.p)] < 11:
+			switch {
+			case lex.data[(lex.p)] > 9:
+				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
+					_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotHeredocEnd(lex.p) {
+						_widec += 256
+					}
+				}
+			default:
+				_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotHeredocEnd(lex.p) {
+					_widec += 256
+				}
+			}
+		case lex.data[(lex.p)] > 12:
+			switch {
+			case lex.data[(lex.p)] > 13:
+				if 14 <= lex.data[(lex.p)] {
+					_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotHeredocEnd(lex.p) {
+						_widec += 256
+					}
+				}
+			case lex.data[(lex.p)] >= 13:
+				_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotHeredocEnd(lex.p) {
+					_widec += 256
+				}
+			}
+		default:
+			_widec = 768 + (int16(lex.data[(lex.p)]) - 0)
+			if lex.isNotHeredocEnd(lex.p) {
+				_widec += 256
+			}
+		}
+		switch _widec {
+		case 1034:
+			goto tr725
+		case 1037:
+			goto tr726
+		}
+		if 1024 <= _widec && _widec <= 1279 {
+			goto tr724
+		}
+		goto tr732
+	tr156:
+		// line internal/php8/scanner.rl:419
 		lex.te = (lex.p) + 1
 		{
 			lex.ungetCnt(1)
 			lex.setTokenPosition(tkn)
 			tok = token.T_CURLY_OPEN
-			lex.call(501, 131)
+			lex.call(504, 133)
 			goto _out
 		}
-		goto st501
-	tr736:
-		// line internal/php8/scanner.rl:410
+		goto st504
+	tr740:
+		// line internal/php8/scanner.rl:421
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -21970,45 +22073,45 @@ func (lex *Lexer) Lex() *token.Token {
 			{
 				lex.growCallStack()
 				{
-					lex.stack[lex.top] = 501
+					lex.stack[lex.top] = 504
 					lex.top++
-					goto st522
+					goto st525
 				}
 			}
 		}
-		goto st501
-	tr737:
-		// line internal/php8/scanner.rl:409
+		goto st504
+	tr741:
+		// line internal/php8/scanner.rl:420
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_DOLLAR_OPEN_CURLY_BRACES
-			lex.call(501, 538)
+			lex.call(504, 542)
 			goto _out
 		}
-		goto st501
-	tr738:
-		lex.cs = 501
+		goto st504
+	tr742:
+		lex.cs = 504
 		// line NONE:1
 		switch lex.act {
-		case 157:
+		case 158:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.ungetCnt(1)
 				lex.setTokenPosition(tkn)
 				tok = token.T_CURLY_OPEN
-				lex.call(501, 131)
+				lex.call(504, 133)
 				goto _out
 			}
-		case 158:
+		case 159:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
 				tok = token.T_DOLLAR_OPEN_CURLY_BRACES
-				lex.call(501, 538)
+				lex.call(504, 542)
 				goto _out
 			}
-		case 160:
+		case 161:
 			{
 				(lex.p) = (lex.te) - 1
 
@@ -22016,7 +22119,7 @@ func (lex *Lexer) Lex() *token.Token {
 				tok = token.T_ENCAPSED_AND_WHITESPACE
 
 				if len(lex.data) > lex.p+1 && lex.data[lex.p+1] != '$' && lex.data[lex.p+1] != '{' {
-					lex.cs = 520
+					lex.cs = 523
 				}
 				{
 					(lex.p)++
@@ -22026,11 +22129,11 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 
 		goto _again
-	tr739:
-		lex.cs = 501
+	tr743:
+		lex.cs = 504
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:411
+		// line internal/php8/scanner.rl:422
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -22038,7 +22141,7 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_ENCAPSED_AND_WHITESPACE
 
 			if len(lex.data) > lex.p+1 && lex.data[lex.p+1] != '$' && lex.data[lex.p+1] != '{' {
-				lex.cs = 520
+				lex.cs = 523
 			}
 			{
 				(lex.p)++
@@ -22046,9 +22149,9 @@ func (lex *Lexer) Lex() *token.Token {
 			}
 		}
 		goto _again
-	tr743:
-		lex.cs = 501
-		// line internal/php8/scanner.rl:411
+	tr747:
+		lex.cs = 504
+		// line internal/php8/scanner.rl:422
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -22056,7 +22159,7 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_ENCAPSED_AND_WHITESPACE
 
 			if len(lex.data) > lex.p+1 && lex.data[lex.p+1] != '$' && lex.data[lex.p+1] != '{' {
-				lex.cs = 520
+				lex.cs = 523
 			}
 			{
 				(lex.p)++
@@ -22064,18 +22167,18 @@ func (lex *Lexer) Lex() *token.Token {
 			}
 		}
 		goto _again
-	st501:
+	st504:
 		// line NONE:1
 		lex.ts = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof501
+			goto _test_eof504
 		}
-	st_case_501:
+	st_case_504:
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:20707
+		// line internal/php8/scanner.go:20787
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -22116,155 +22219,75 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1316:
-			goto st502
+			goto st505
 		case 1403:
-			goto st106
+			goto st107
 		case 1546:
-			goto tr732
+			goto tr736
 		case 1549:
-			goto tr733
+			goto tr737
 		case 1572:
-			goto st506
+			goto st509
 		case 1659:
-			goto st507
+			goto st510
 		}
 		if 1536 <= _widec && _widec <= 1791 {
-			goto tr731
+			goto tr735
 		}
 		goto st0
-	st502:
+	st505:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof502
+			goto _test_eof505
 		}
-	st_case_502:
+	st_case_505:
 		if lex.data[(lex.p)] == 123 {
-			goto tr737
+			goto tr741
 		}
-		goto tr736
-	st106:
+		goto tr740
+	st107:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof106
+			goto _test_eof107
 		}
-	st_case_106:
+	st_case_107:
 		if lex.data[(lex.p)] == 36 {
-			goto tr155
+			goto tr156
 		}
 		goto st0
-	tr731:
+	tr735:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:411
-		lex.act = 160
-		goto st503
-	tr740:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:411
-		lex.act = 160
-		goto st503
+		// line internal/php8/scanner.rl:422
+		lex.act = 161
+		goto st506
 	tr744:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:409
-		lex.act = 158
-		goto st503
-	tr745:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:422
+		lex.act = 161
+		goto st506
+	tr748:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:408
-		lex.act = 157
-		goto st503
-	st503:
+		// line internal/php8/scanner.rl:420
+		lex.act = 159
+		goto st506
+	tr749:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:419
+		lex.act = 158
+		goto st506
+	st506:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof503
+			goto _test_eof506
 		}
-	st_case_503:
-		// line internal/php8/scanner.go:20817
-		_widec = int16(lex.data[(lex.p)])
-		switch {
-		case lex.data[(lex.p)] < 11:
-			switch {
-			case lex.data[(lex.p)] > 9:
-				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
-					_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
-						_widec += 256
-					}
-				}
-			default:
-				_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
-					_widec += 256
-				}
-			}
-		case lex.data[(lex.p)] > 12:
-			switch {
-			case lex.data[(lex.p)] > 13:
-				if 14 <= lex.data[(lex.p)] {
-					_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
-						_widec += 256
-					}
-				}
-			case lex.data[(lex.p)] >= 13:
-				_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
-					_widec += 256
-				}
-			}
-		default:
-			_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
-			if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
-				_widec += 256
-			}
-		}
-		switch _widec {
-		case 1546:
-			goto tr732
-		case 1549:
-			goto tr733
-		}
-		if 1536 <= _widec && _widec <= 1791 {
-			goto tr731
-		}
-		goto tr738
-	tr732:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st504
-	tr741:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st504
-	st504:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof504
-		}
-	st_case_504:
+	st_case_506:
 		// line internal/php8/scanner.go:20897
 		_widec = int16(lex.data[(lex.p)])
 		switch {
@@ -22306,15 +22329,15 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1546:
-			goto tr741
+			goto tr736
 		case 1549:
-			goto tr742
+			goto tr737
 		}
 		if 1536 <= _widec && _widec <= 1791 {
-			goto tr740
+			goto tr735
 		}
-		goto tr739
-	tr733:
+		goto tr742
+	tr736:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -22325,8 +22348,8 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st505
-	tr742:
+		goto st507
+	tr745:
 		// line internal/php8/scanner.rl:54
 
 		// line internal/php8/scanner.rl:38
@@ -22339,12 +22362,12 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st505
-	st505:
+		goto st507
+	st507:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof505
+			goto _test_eof507
 		}
-	st_case_505:
+	st_case_507:
 		// line internal/php8/scanner.go:20977
 		_widec = int16(lex.data[(lex.p)])
 		switch {
@@ -22386,19 +22409,99 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1546:
-			goto tr732
+			goto tr745
 		case 1549:
-			goto tr733
+			goto tr746
 		}
 		if 1536 <= _widec && _widec <= 1791 {
-			goto tr731
+			goto tr744
 		}
 		goto tr743
-	st506:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof506
+	tr737:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
 		}
-	st_case_506:
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st508
+	tr746:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st508
+	st508:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof508
+		}
+	st_case_508:
+		// line internal/php8/scanner.go:21057
+		_widec = int16(lex.data[(lex.p)])
+		switch {
+		case lex.data[(lex.p)] < 11:
+			switch {
+			case lex.data[(lex.p)] > 9:
+				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
+					_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
+						_widec += 256
+					}
+				}
+			default:
+				_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
+					_widec += 256
+				}
+			}
+		case lex.data[(lex.p)] > 12:
+			switch {
+			case lex.data[(lex.p)] > 13:
+				if 14 <= lex.data[(lex.p)] {
+					_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
+						_widec += 256
+					}
+				}
+			case lex.data[(lex.p)] >= 13:
+				_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
+					_widec += 256
+				}
+			}
+		default:
+			_widec = 1280 + (int16(lex.data[(lex.p)]) - 0)
+			if lex.isNotHeredocEnd(lex.p) && lex.isNotStringVar() {
+				_widec += 256
+			}
+		}
+		switch _widec {
+		case 1546:
+			goto tr736
+		case 1549:
+			goto tr737
+		}
+		if 1536 <= _widec && _widec <= 1791 {
+			goto tr735
+		}
+		goto tr747
+	st509:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof509
+		}
+	st_case_509:
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -22439,23 +22542,23 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1403:
-			goto tr737
+			goto tr741
 		case 1546:
-			goto tr732
+			goto tr736
 		case 1549:
-			goto tr733
+			goto tr737
 		case 1659:
-			goto tr744
+			goto tr748
 		}
 		if 1536 <= _widec && _widec <= 1791 {
-			goto tr731
+			goto tr735
 		}
-		goto tr736
-	st507:
+		goto tr740
+	st510:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof507
+			goto _test_eof510
 		}
-	st_case_507:
+	st_case_510:
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -22496,114 +22599,114 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1316:
-			goto tr155
+			goto tr156
 		case 1546:
-			goto tr732
+			goto tr736
 		case 1549:
-			goto tr733
+			goto tr737
 		case 1572:
-			goto tr745
+			goto tr749
 		}
 		if 1536 <= _widec && _widec <= 1791 {
-			goto tr731
+			goto tr735
 		}
-		goto tr743
-	tr157:
-		// line internal/php8/scanner.rl:425
+		goto tr747
+	tr158:
+		// line internal/php8/scanner.rl:436
 		lex.te = (lex.p) + 1
 		{
 			lex.ungetCnt(2)
 			{
 				lex.growCallStack()
 				{
-					lex.stack[lex.top] = 508
+					lex.stack[lex.top] = 511
 					lex.top++
-					goto st522
+					goto st525
 				}
 			}
 		}
-		goto st508
-	tr158:
-		// line internal/php8/scanner.rl:424
+		goto st511
+	tr159:
+		// line internal/php8/scanner.rl:435
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_DOLLAR_OPEN_CURLY_BRACES
-			lex.call(508, 538)
+			lex.call(511, 542)
 			goto _out
 		}
-		goto st508
-	tr159:
-		// line internal/php8/scanner.rl:423
+		goto st511
+	tr160:
+		// line internal/php8/scanner.rl:434
 		lex.te = (lex.p) + 1
 		{
 			lex.ungetCnt(1)
 			lex.setTokenPosition(tkn)
 			tok = token.T_CURLY_OPEN
-			lex.call(508, 131)
+			lex.call(511, 133)
 			goto _out
 		}
-		goto st508
-	tr747:
-		lex.cs = 508
-		// line internal/php8/scanner.rl:426
+		goto st511
+	tr751:
+		lex.cs = 511
+		// line internal/php8/scanner.rl:437
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int('`'))
-			lex.cs = 131
+			lex.cs = 133
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr755:
-		lex.cs = 508
+	tr759:
+		lex.cs = 511
 		// line NONE:1
 		switch lex.act {
-		case 161:
+		case 162:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.ungetCnt(1)
 				lex.setTokenPosition(tkn)
 				tok = token.T_CURLY_OPEN
-				lex.call(508, 131)
+				lex.call(511, 133)
 				goto _out
 			}
-		case 162:
+		case 163:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
 				tok = token.T_DOLLAR_OPEN_CURLY_BRACES
-				lex.call(508, 538)
+				lex.call(511, 542)
 				goto _out
 			}
-		case 163:
+		case 164:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.ungetCnt(2)
 				{
 					lex.growCallStack()
 					{
-						lex.stack[lex.top] = 508
+						lex.stack[lex.top] = 511
 						lex.top++
-						goto st522
+						goto st525
 					}
 				}
 			}
-		case 164:
+		case 165:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
 				tok = token.ID(int('`'))
-				lex.cs = 131
+				lex.cs = 133
 				{
 					(lex.p)++
 					goto _out
 				}
 			}
-		case 165:
+		case 166:
 			{
 				(lex.p) = (lex.te) - 1
 
@@ -22617,10 +22720,10 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 
 		goto _again
-	tr756:
+	tr760:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:427
+		// line internal/php8/scanner.rl:438
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -22628,13 +22731,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_ENCAPSED_AND_WHITESPACE
 			{
 				(lex.p)++
-				lex.cs = 508
+				lex.cs = 511
 				goto _out
 			}
 		}
-		goto st508
-	tr760:
-		// line internal/php8/scanner.rl:427
+		goto st511
+	tr764:
+		// line internal/php8/scanner.rl:438
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -22642,23 +22745,23 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_ENCAPSED_AND_WHITESPACE
 			{
 				(lex.p)++
-				lex.cs = 508
+				lex.cs = 511
 				goto _out
 			}
 		}
-		goto st508
-	st508:
+		goto st511
+	st511:
 		// line NONE:1
 		lex.ts = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof508
+			goto _test_eof511
 		}
-	st_case_508:
+	st_case_511:
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:21220
+		// line internal/php8/scanner.go:21300
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -22699,36 +22802,36 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1828:
-			goto st107
-		case 1888:
-			goto tr747
-		case 1915:
 			goto st108
-		case 2058:
-			goto tr750
-		case 2061:
+		case 1888:
 			goto tr751
+		case 1915:
+			goto st109
+		case 2058:
+			goto tr754
+		case 2061:
+			goto tr755
 		case 2084:
-			goto st512
+			goto st515
 		case 2144:
-			goto tr753
+			goto tr757
 		case 2171:
-			goto st513
+			goto st516
 		}
 		if 2048 <= _widec && _widec <= 2303 {
-			goto tr749
+			goto tr753
 		}
 		goto st0
-	st107:
+	st108:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof107
+			goto _test_eof108
 		}
-	st_case_107:
+	st_case_108:
 		switch lex.data[(lex.p)] {
 		case 96:
 			goto st0
 		case 123:
-			goto tr158
+			goto tr159
 		}
 		switch {
 		case lex.data[(lex.p)] < 91:
@@ -22742,145 +22845,65 @@ func (lex *Lexer) Lex() *token.Token {
 		default:
 			goto st0
 		}
-		goto tr157
-	st108:
+		goto tr158
+	st109:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof108
+			goto _test_eof109
 		}
-	st_case_108:
+	st_case_109:
 		if lex.data[(lex.p)] == 36 {
-			goto tr159
+			goto tr160
 		}
 		goto st0
-	tr749:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:427
-		lex.act = 165
-		goto st509
 	tr753:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:426
-		lex.act = 164
-		goto st509
+		// line internal/php8/scanner.rl:438
+		lex.act = 166
+		goto st512
 	tr757:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:427
+		// line internal/php8/scanner.rl:437
 		lex.act = 165
-		goto st509
+		goto st512
 	tr761:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:425
-		lex.act = 163
-		goto st509
-	tr762:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:424
-		lex.act = 162
-		goto st509
-	tr763:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:423
-		lex.act = 161
-		goto st509
-	st509:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof509
-		}
-	st_case_509:
-		// line internal/php8/scanner.go:21363
-		_widec = int16(lex.data[(lex.p)])
-		switch {
-		case lex.data[(lex.p)] < 11:
-			switch {
-			case lex.data[(lex.p)] > 9:
-				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
-					_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotStringEnd('`') && lex.isNotStringVar() {
-						_widec += 256
-					}
-				}
-			default:
-				_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotStringEnd('`') && lex.isNotStringVar() {
-					_widec += 256
-				}
-			}
-		case lex.data[(lex.p)] > 12:
-			switch {
-			case lex.data[(lex.p)] > 13:
-				if 14 <= lex.data[(lex.p)] {
-					_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotStringEnd('`') && lex.isNotStringVar() {
-						_widec += 256
-					}
-				}
-			case lex.data[(lex.p)] >= 13:
-				_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotStringEnd('`') && lex.isNotStringVar() {
-					_widec += 256
-				}
-			}
-		default:
-			_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
-			if lex.isNotStringEnd('`') && lex.isNotStringVar() {
-				_widec += 256
-			}
-		}
-		switch _widec {
-		case 2058:
-			goto tr750
-		case 2061:
-			goto tr751
-		}
-		if 2048 <= _widec && _widec <= 2303 {
-			goto tr749
-		}
-		goto tr755
-	tr750:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st510
-	tr758:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:38
+		// line internal/php8/scanner.rl:438
+		lex.act = 166
+		goto st512
+	tr765:
+		// line NONE:1
+		lex.te = (lex.p) + 1
 
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
+		// line internal/php8/scanner.rl:436
+		lex.act = 164
+		goto st512
+	tr766:
+		// line NONE:1
+		lex.te = (lex.p) + 1
 
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
+		// line internal/php8/scanner.rl:435
+		lex.act = 163
+		goto st512
+	tr767:
+		// line NONE:1
+		lex.te = (lex.p) + 1
 
-		goto st510
-	st510:
+		// line internal/php8/scanner.rl:434
+		lex.act = 162
+		goto st512
+	st512:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof510
+			goto _test_eof512
 		}
-	st_case_510:
+	st_case_512:
 		// line internal/php8/scanner.go:21443
 		_widec = int16(lex.data[(lex.p)])
 		switch {
@@ -22922,15 +22945,15 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 2058:
-			goto tr758
+			goto tr754
 		case 2061:
-			goto tr759
+			goto tr755
 		}
 		if 2048 <= _widec && _widec <= 2303 {
-			goto tr757
+			goto tr753
 		}
-		goto tr756
-	tr751:
+		goto tr759
+	tr754:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -22941,8 +22964,8 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st511
-	tr759:
+		goto st513
+	tr762:
 		// line internal/php8/scanner.rl:54
 
 		// line internal/php8/scanner.rl:38
@@ -22955,12 +22978,12 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st511
-	st511:
+		goto st513
+	st513:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof511
+			goto _test_eof513
 		}
-	st_case_511:
+	st_case_513:
 		// line internal/php8/scanner.go:21523
 		_widec = int16(lex.data[(lex.p)])
 		switch {
@@ -23002,19 +23025,99 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 2058:
-			goto tr750
+			goto tr762
 		case 2061:
-			goto tr751
+			goto tr763
 		}
 		if 2048 <= _widec && _widec <= 2303 {
-			goto tr749
+			goto tr761
 		}
 		goto tr760
-	st512:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof512
+	tr755:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
 		}
-	st_case_512:
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st514
+	tr763:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st514
+	st514:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof514
+		}
+	st_case_514:
+		// line internal/php8/scanner.go:21603
+		_widec = int16(lex.data[(lex.p)])
+		switch {
+		case lex.data[(lex.p)] < 11:
+			switch {
+			case lex.data[(lex.p)] > 9:
+				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
+					_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotStringEnd('`') && lex.isNotStringVar() {
+						_widec += 256
+					}
+				}
+			default:
+				_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotStringEnd('`') && lex.isNotStringVar() {
+					_widec += 256
+				}
+			}
+		case lex.data[(lex.p)] > 12:
+			switch {
+			case lex.data[(lex.p)] > 13:
+				if 14 <= lex.data[(lex.p)] {
+					_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotStringEnd('`') && lex.isNotStringVar() {
+						_widec += 256
+					}
+				}
+			case lex.data[(lex.p)] >= 13:
+				_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotStringEnd('`') && lex.isNotStringVar() {
+					_widec += 256
+				}
+			}
+		default:
+			_widec = 1792 + (int16(lex.data[(lex.p)]) - 0)
+			if lex.isNotStringEnd('`') && lex.isNotStringVar() {
+				_widec += 256
+			}
+		}
+		switch _widec {
+		case 2058:
+			goto tr754
+		case 2061:
+			goto tr755
+		}
+		if 2048 <= _widec && _widec <= 2303 {
+			goto tr753
+		}
+		goto tr764
+	st515:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof515
+		}
+	st_case_515:
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -23055,64 +23158,64 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1887:
-			goto tr157
-		case 1915:
 			goto tr158
+		case 1915:
+			goto tr159
 		case 2058:
-			goto tr750
+			goto tr754
 		case 2061:
-			goto tr751
+			goto tr755
 		case 2143:
-			goto tr761
+			goto tr765
 		case 2171:
-			goto tr762
+			goto tr766
 		}
 		switch {
 		case _widec < 2113:
 			switch {
 			case _widec < 1889:
 				if 1857 <= _widec && _widec <= 1882 {
-					goto tr157
+					goto tr158
 				}
 			case _widec > 1914:
 				switch {
 				case _widec > 2047:
 					if 2048 <= _widec && _widec <= 2112 {
-						goto tr749
+						goto tr753
 					}
 				case _widec >= 1920:
-					goto tr157
+					goto tr158
 				}
 			default:
-				goto tr157
+				goto tr158
 			}
 		case _widec > 2138:
 			switch {
 			case _widec < 2145:
 				if 2139 <= _widec && _widec <= 2144 {
-					goto tr749
+					goto tr753
 				}
 			case _widec > 2170:
 				switch {
 				case _widec > 2175:
 					if 2176 <= _widec && _widec <= 2303 {
-						goto tr761
+						goto tr765
 					}
 				case _widec >= 2172:
-					goto tr749
+					goto tr753
 				}
 			default:
-				goto tr761
+				goto tr765
 			}
 		default:
-			goto tr761
+			goto tr765
 		}
-		goto tr760
-	st513:
+		goto tr764
+	st516:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof513
+			goto _test_eof516
 		}
-	st_case_513:
+	st_case_516:
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -23153,114 +23256,114 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 1828:
-			goto tr159
+			goto tr160
 		case 2058:
-			goto tr750
+			goto tr754
 		case 2061:
-			goto tr751
+			goto tr755
 		case 2084:
-			goto tr763
+			goto tr767
 		}
 		if 2048 <= _widec && _widec <= 2303 {
-			goto tr749
+			goto tr753
 		}
-		goto tr760
-	tr160:
-		// line internal/php8/scanner.rl:437
+		goto tr764
+	tr161:
+		// line internal/php8/scanner.rl:448
 		lex.te = (lex.p) + 1
 		{
 			lex.ungetCnt(2)
 			{
 				lex.growCallStack()
 				{
-					lex.stack[lex.top] = 514
+					lex.stack[lex.top] = 517
 					lex.top++
-					goto st522
+					goto st525
 				}
 			}
 		}
-		goto st514
-	tr161:
-		// line internal/php8/scanner.rl:436
+		goto st517
+	tr162:
+		// line internal/php8/scanner.rl:447
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_DOLLAR_OPEN_CURLY_BRACES
-			lex.call(514, 538)
+			lex.call(517, 542)
 			goto _out
 		}
-		goto st514
-	tr162:
-		// line internal/php8/scanner.rl:435
+		goto st517
+	tr163:
+		// line internal/php8/scanner.rl:446
 		lex.te = (lex.p) + 1
 		{
 			lex.ungetCnt(1)
 			lex.setTokenPosition(tkn)
 			tok = token.T_CURLY_OPEN
-			lex.call(514, 131)
+			lex.call(517, 133)
 			goto _out
 		}
-		goto st514
-	tr764:
-		lex.cs = 514
-		// line internal/php8/scanner.rl:438
+		goto st517
+	tr768:
+		lex.cs = 517
+		// line internal/php8/scanner.rl:449
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.ID(int('"'))
-			lex.cs = 131
+			lex.cs = 133
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	tr773:
-		lex.cs = 514
+	tr777:
+		lex.cs = 517
 		// line NONE:1
 		switch lex.act {
-		case 166:
+		case 167:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.ungetCnt(1)
 				lex.setTokenPosition(tkn)
 				tok = token.T_CURLY_OPEN
-				lex.call(514, 131)
+				lex.call(517, 133)
 				goto _out
 			}
-		case 167:
+		case 168:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
 				tok = token.T_DOLLAR_OPEN_CURLY_BRACES
-				lex.call(514, 538)
+				lex.call(517, 542)
 				goto _out
 			}
-		case 168:
+		case 169:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.ungetCnt(2)
 				{
 					lex.growCallStack()
 					{
-						lex.stack[lex.top] = 514
+						lex.stack[lex.top] = 517
 						lex.top++
-						goto st522
+						goto st525
 					}
 				}
 			}
-		case 169:
+		case 170:
 			{
 				(lex.p) = (lex.te) - 1
 				lex.setTokenPosition(tkn)
 				tok = token.ID(int('"'))
-				lex.cs = 131
+				lex.cs = 133
 				{
 					(lex.p)++
 					goto _out
 				}
 			}
-		case 170:
+		case 171:
 			{
 				(lex.p) = (lex.te) - 1
 
@@ -23274,10 +23377,10 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 
 		goto _again
-	tr774:
+	tr778:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:439
+		// line internal/php8/scanner.rl:450
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -23285,13 +23388,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_ENCAPSED_AND_WHITESPACE
 			{
 				(lex.p)++
-				lex.cs = 514
+				lex.cs = 517
 				goto _out
 			}
 		}
-		goto st514
-	tr778:
-		// line internal/php8/scanner.rl:439
+		goto st517
+	tr782:
+		// line internal/php8/scanner.rl:450
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -23299,23 +23402,23 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_ENCAPSED_AND_WHITESPACE
 			{
 				(lex.p)++
-				lex.cs = 514
+				lex.cs = 517
 				goto _out
 			}
 		}
-		goto st514
-	st514:
+		goto st517
+	st517:
 		// line NONE:1
 		lex.ts = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof514
+			goto _test_eof517
 		}
-	st_case_514:
+	st_case_517:
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:21807
+		// line internal/php8/scanner.go:21887
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -23356,36 +23459,36 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 2338:
-			goto tr764
-		case 2340:
-			goto st109
-		case 2427:
-			goto st110
-		case 2570:
 			goto tr768
+		case 2340:
+			goto st110
+		case 2427:
+			goto st111
+		case 2570:
+			goto tr772
 		case 2573:
-			goto tr769
+			goto tr773
 		case 2594:
-			goto tr770
+			goto tr774
 		case 2596:
-			goto st518
+			goto st521
 		case 2683:
-			goto st519
+			goto st522
 		}
 		if 2560 <= _widec && _widec <= 2815 {
-			goto tr767
+			goto tr771
 		}
 		goto st0
-	st109:
+	st110:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof109
+			goto _test_eof110
 		}
-	st_case_109:
+	st_case_110:
 		switch lex.data[(lex.p)] {
 		case 96:
 			goto st0
 		case 123:
-			goto tr161
+			goto tr162
 		}
 		switch {
 		case lex.data[(lex.p)] < 91:
@@ -23399,145 +23502,65 @@ func (lex *Lexer) Lex() *token.Token {
 		default:
 			goto st0
 		}
-		goto tr160
-	st110:
+		goto tr161
+	st111:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof110
+			goto _test_eof111
 		}
-	st_case_110:
+	st_case_111:
 		if lex.data[(lex.p)] == 36 {
-			goto tr162
+			goto tr163
 		}
 		goto st0
-	tr767:
+	tr771:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:439
+		// line internal/php8/scanner.rl:450
+		lex.act = 171
+		goto st518
+	tr774:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:449
 		lex.act = 170
-		goto st515
-	tr770:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:438
-		lex.act = 169
-		goto st515
-	tr775:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:439
-		lex.act = 170
-		goto st515
+		goto st518
 	tr779:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:437
-		lex.act = 168
-		goto st515
-	tr780:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:436
-		lex.act = 167
-		goto st515
-	tr781:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:435
-		lex.act = 166
-		goto st515
-	st515:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof515
-		}
-	st_case_515:
-		// line internal/php8/scanner.go:21950
-		_widec = int16(lex.data[(lex.p)])
-		switch {
-		case lex.data[(lex.p)] < 11:
-			switch {
-			case lex.data[(lex.p)] > 9:
-				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
-					_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotStringEnd('"') && lex.isNotStringVar() {
-						_widec += 256
-					}
-				}
-			default:
-				_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotStringEnd('"') && lex.isNotStringVar() {
-					_widec += 256
-				}
-			}
-		case lex.data[(lex.p)] > 12:
-			switch {
-			case lex.data[(lex.p)] > 13:
-				if 14 <= lex.data[(lex.p)] {
-					_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
-					if lex.isNotStringEnd('"') && lex.isNotStringVar() {
-						_widec += 256
-					}
-				}
-			case lex.data[(lex.p)] >= 13:
-				_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
-				if lex.isNotStringEnd('"') && lex.isNotStringVar() {
-					_widec += 256
-				}
-			}
-		default:
-			_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
-			if lex.isNotStringEnd('"') && lex.isNotStringVar() {
-				_widec += 256
-			}
-		}
-		switch _widec {
-		case 2570:
-			goto tr768
-		case 2573:
-			goto tr769
-		}
-		if 2560 <= _widec && _widec <= 2815 {
-			goto tr767
-		}
-		goto tr773
-	tr768:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st516
-	tr776:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:38
+		// line internal/php8/scanner.rl:450
+		lex.act = 171
+		goto st518
+	tr783:
+		// line NONE:1
+		lex.te = (lex.p) + 1
 
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
+		// line internal/php8/scanner.rl:448
+		lex.act = 169
+		goto st518
+	tr784:
+		// line NONE:1
+		lex.te = (lex.p) + 1
 
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
+		// line internal/php8/scanner.rl:447
+		lex.act = 168
+		goto st518
+	tr785:
+		// line NONE:1
+		lex.te = (lex.p) + 1
 
-		goto st516
-	st516:
+		// line internal/php8/scanner.rl:446
+		lex.act = 167
+		goto st518
+	st518:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof516
+			goto _test_eof518
 		}
-	st_case_516:
+	st_case_518:
 		// line internal/php8/scanner.go:22030
 		_widec = int16(lex.data[(lex.p)])
 		switch {
@@ -23579,15 +23602,15 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 2570:
-			goto tr776
+			goto tr772
 		case 2573:
-			goto tr777
+			goto tr773
 		}
 		if 2560 <= _widec && _widec <= 2815 {
-			goto tr775
+			goto tr771
 		}
-		goto tr774
-	tr769:
+		goto tr777
+	tr772:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -23598,8 +23621,8 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st517
-	tr777:
+		goto st519
+	tr780:
 		// line internal/php8/scanner.rl:54
 
 		// line internal/php8/scanner.rl:38
@@ -23612,12 +23635,12 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st517
-	st517:
+		goto st519
+	st519:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof517
+			goto _test_eof519
 		}
-	st_case_517:
+	st_case_519:
 		// line internal/php8/scanner.go:22110
 		_widec = int16(lex.data[(lex.p)])
 		switch {
@@ -23659,19 +23682,99 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 2570:
-			goto tr768
+			goto tr780
 		case 2573:
-			goto tr769
+			goto tr781
 		}
 		if 2560 <= _widec && _widec <= 2815 {
-			goto tr767
+			goto tr779
 		}
 		goto tr778
-	st518:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof518
+	tr773:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
 		}
-	st_case_518:
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st520
+	tr781:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st520
+	st520:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof520
+		}
+	st_case_520:
+		// line internal/php8/scanner.go:22190
+		_widec = int16(lex.data[(lex.p)])
+		switch {
+		case lex.data[(lex.p)] < 11:
+			switch {
+			case lex.data[(lex.p)] > 9:
+				if 10 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 10 {
+					_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotStringEnd('"') && lex.isNotStringVar() {
+						_widec += 256
+					}
+				}
+			default:
+				_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotStringEnd('"') && lex.isNotStringVar() {
+					_widec += 256
+				}
+			}
+		case lex.data[(lex.p)] > 12:
+			switch {
+			case lex.data[(lex.p)] > 13:
+				if 14 <= lex.data[(lex.p)] {
+					_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
+					if lex.isNotStringEnd('"') && lex.isNotStringVar() {
+						_widec += 256
+					}
+				}
+			case lex.data[(lex.p)] >= 13:
+				_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
+				if lex.isNotStringEnd('"') && lex.isNotStringVar() {
+					_widec += 256
+				}
+			}
+		default:
+			_widec = 2304 + (int16(lex.data[(lex.p)]) - 0)
+			if lex.isNotStringEnd('"') && lex.isNotStringVar() {
+				_widec += 256
+			}
+		}
+		switch _widec {
+		case 2570:
+			goto tr772
+		case 2573:
+			goto tr773
+		}
+		if 2560 <= _widec && _widec <= 2815 {
+			goto tr771
+		}
+		goto tr782
+	st521:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof521
+		}
+	st_case_521:
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -23712,64 +23815,64 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 2399:
-			goto tr160
-		case 2427:
 			goto tr161
+		case 2427:
+			goto tr162
 		case 2570:
-			goto tr768
+			goto tr772
 		case 2573:
-			goto tr769
+			goto tr773
 		case 2655:
-			goto tr779
+			goto tr783
 		case 2683:
-			goto tr780
+			goto tr784
 		}
 		switch {
 		case _widec < 2625:
 			switch {
 			case _widec < 2401:
 				if 2369 <= _widec && _widec <= 2394 {
-					goto tr160
+					goto tr161
 				}
 			case _widec > 2426:
 				switch {
 				case _widec > 2559:
 					if 2560 <= _widec && _widec <= 2624 {
-						goto tr767
+						goto tr771
 					}
 				case _widec >= 2432:
-					goto tr160
+					goto tr161
 				}
 			default:
-				goto tr160
+				goto tr161
 			}
 		case _widec > 2650:
 			switch {
 			case _widec < 2657:
 				if 2651 <= _widec && _widec <= 2656 {
-					goto tr767
+					goto tr771
 				}
 			case _widec > 2682:
 				switch {
 				case _widec > 2687:
 					if 2688 <= _widec && _widec <= 2815 {
-						goto tr779
+						goto tr783
 					}
 				case _widec >= 2684:
-					goto tr767
+					goto tr771
 				}
 			default:
-				goto tr779
+				goto tr783
 			}
 		default:
-			goto tr779
+			goto tr783
 		}
-		goto tr778
-	st519:
+		goto tr782
+	st522:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof519
+			goto _test_eof522
 		}
-	st_case_519:
+	st_case_522:
 		_widec = int16(lex.data[(lex.p)])
 		switch {
 		case lex.data[(lex.p)] < 11:
@@ -23810,246 +23913,59 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		switch _widec {
 		case 2340:
-			goto tr162
+			goto tr163
 		case 2570:
-			goto tr768
+			goto tr772
 		case 2573:
-			goto tr769
+			goto tr773
 		case 2596:
-			goto tr781
+			goto tr785
 		}
 		if 2560 <= _widec && _widec <= 2815 {
-			goto tr767
+			goto tr771
 		}
-		goto tr778
-	tr783:
-		lex.cs = 520
-		// line internal/php8/scanner.rl:447
+		goto tr782
+	tr787:
+		lex.cs = 523
+		// line internal/php8/scanner.rl:458
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.setTokenPosition(tkn)
 			tok = token.T_END_HEREDOC
-			lex.cs = 131
+			lex.cs = 133
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
-	st520:
-		// line NONE:1
-		lex.ts = 0
-
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof520
-		}
-	st_case_520:
-		// line NONE:1
-		lex.ts = (lex.p)
-
-		// line internal/php8/scanner.go:22337
-		if lex.data[(lex.p)] == 96 {
-			goto st0
-		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto st0
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto st0
-			}
-		default:
-			goto st0
-		}
-		goto st521
-	st521:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof521
-		}
-	st_case_521:
-		if lex.data[(lex.p)] == 96 {
-			goto tr783
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr783
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr783
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr783
-			}
-		default:
-			goto tr783
-		}
-		goto st521
-	tr163:
-		// line internal/php8/scanner.rl:467
-		(lex.p) = (lex.te) - 1
-		{
-			lex.ungetCnt(1)
-			{
-				lex.top--
-				lex.cs = lex.stack[lex.top]
-				goto _again
-			}
-		}
-		goto st522
-	tr164:
-		// line internal/php8/scanner.rl:463
-		lex.te = (lex.p) + 1
-		{
-			lex.ungetCnt(1)
-			lex.setTokenPosition(tkn)
-			tok = token.T_OBJECT_OPERATOR
-			{
-				(lex.p)++
-				lex.cs = 522
-				goto _out
-			}
-		}
-		goto st522
-	tr166:
-		// line internal/php8/scanner.rl:464
-		lex.te = (lex.p) + 1
-		{
-			lex.ungetCnt(1)
-			lex.setTokenPosition(tkn)
-			tok = token.T_NULLSAFE_OBJECT_OPERATOR
-			{
-				(lex.p)++
-				lex.cs = 522
-				goto _out
-			}
-		}
-		goto st522
-	tr784:
-		// line internal/php8/scanner.rl:467
-		lex.te = (lex.p) + 1
-		{
-			lex.ungetCnt(1)
-			{
-				lex.top--
-				lex.cs = lex.stack[lex.top]
-				goto _again
-			}
-		}
-		goto st522
-	tr789:
-		// line internal/php8/scanner.rl:466
-		lex.te = (lex.p) + 1
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.ID(int('['))
-			lex.call(522, 528)
-			goto _out
-		}
-		goto st522
-	tr790:
-		// line internal/php8/scanner.rl:467
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.ungetCnt(1)
-			{
-				lex.top--
-				lex.cs = lex.stack[lex.top]
-				goto _again
-			}
-		}
-		goto st522
-	tr792:
-		// line internal/php8/scanner.rl:462
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_VARIABLE
-			{
-				(lex.p)++
-				lex.cs = 522
-				goto _out
-			}
-		}
-		goto st522
-	tr795:
-		// line internal/php8/scanner.rl:465
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_STRING
-			{
-				(lex.p)++
-				lex.cs = 522
-				goto _out
-			}
-		}
-		goto st522
-	st522:
-		// line NONE:1
-		lex.ts = 0
-
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof522
-		}
-	st_case_522:
-		// line NONE:1
-		lex.ts = (lex.p)
-
-		// line internal/php8/scanner.go:22434
-		switch lex.data[(lex.p)] {
-		case 36:
-			goto st523
-		case 45:
-			goto tr786
-		case 63:
-			goto tr787
-		case 91:
-			goto tr789
-		case 96:
-			goto tr784
-		}
-		switch {
-		case lex.data[(lex.p)] < 92:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr784
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr784
-			}
-		default:
-			goto tr784
-		}
-		goto st527
 	st523:
+		// line NONE:1
+		lex.ts = 0
+
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof523
 		}
 	st_case_523:
+		// line NONE:1
+		lex.ts = (lex.p)
+
+		// line internal/php8/scanner.go:22417
 		if lex.data[(lex.p)] == 96 {
-			goto tr790
+			goto st0
 		}
 		switch {
 		case lex.data[(lex.p)] < 91:
 			if lex.data[(lex.p)] <= 64 {
-				goto tr790
+				goto st0
 			}
 		case lex.data[(lex.p)] > 94:
 			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr790
+				goto st0
 			}
 		default:
-			goto tr790
+			goto st0
 		}
 		goto st524
 	st524:
@@ -24058,225 +23974,103 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 	st_case_524:
 		if lex.data[(lex.p)] == 96 {
-			goto tr792
+			goto tr787
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr792
+				goto tr787
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr792
+					goto tr787
 				}
 			case lex.data[(lex.p)] >= 91:
-				goto tr792
+				goto tr787
 			}
 		default:
-			goto tr792
+			goto tr787
 		}
 		goto st524
-	tr786:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st525
-	st525:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof525
-		}
-	st_case_525:
-		// line internal/php8/scanner.go:22517
-		if lex.data[(lex.p)] == 62 {
-			goto st111
-		}
-		goto tr790
-	st111:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof111
-		}
-	st_case_111:
-		if lex.data[(lex.p)] == 96 {
-			goto tr163
-		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr163
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr163
-			}
-		default:
-			goto tr163
-		}
-		goto tr164
-	tr787:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st526
-	st526:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof526
-		}
-	st_case_526:
-		// line internal/php8/scanner.go:22553
-		if lex.data[(lex.p)] == 45 {
-			goto st112
-		}
-		goto tr790
-	st112:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof112
-		}
-	st_case_112:
-		if lex.data[(lex.p)] == 62 {
-			goto st113
-		}
-		goto tr163
-	st113:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof113
-		}
-	st_case_113:
-		if lex.data[(lex.p)] == 96 {
-			goto tr163
-		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr163
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr163
-			}
-		default:
-			goto tr163
-		}
-		goto tr166
-	st527:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof527
-		}
-	st_case_527:
-		if lex.data[(lex.p)] == 96 {
-			goto tr795
-		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr795
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr795
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr795
-			}
-		default:
-			goto tr795
-		}
-		goto st527
-	tr167:
-		// line internal/php8/scanner.rl:471
+	tr164:
+		// line internal/php8/scanner.rl:478
 		(lex.p) = (lex.te) - 1
 		{
+			lex.ungetCnt(1)
+			{
+				lex.top--
+				lex.cs = lex.stack[lex.top]
+				goto _again
+			}
+		}
+		goto st525
+	tr165:
+		// line internal/php8/scanner.rl:474
+		lex.te = (lex.p) + 1
+		{
+			lex.ungetCnt(1)
 			lex.setTokenPosition(tkn)
-			tok = token.T_NUM_STRING
+			tok = token.T_OBJECT_OPERATOR
 			{
 				(lex.p)++
-				lex.cs = 528
+				lex.cs = 525
 				goto _out
 			}
 		}
-		goto st528
+		goto st525
+	tr167:
+		// line internal/php8/scanner.rl:475
+		lex.te = (lex.p) + 1
+		{
+			lex.ungetCnt(1)
+			lex.setTokenPosition(tkn)
+			tok = token.T_NULLSAFE_OBJECT_OPERATOR
+			{
+				(lex.p)++
+				lex.cs = 525
+				goto _out
+			}
+		}
+		goto st525
+	tr788:
+		// line internal/php8/scanner.rl:478
+		lex.te = (lex.p) + 1
+		{
+			lex.ungetCnt(1)
+			{
+				lex.top--
+				lex.cs = lex.stack[lex.top]
+				goto _again
+			}
+		}
+		goto st525
+	tr793:
+		// line internal/php8/scanner.rl:477
+		lex.te = (lex.p) + 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.ID(int('['))
+			lex.call(525, 531)
+			goto _out
+		}
+		goto st525
+	tr794:
+		// line internal/php8/scanner.rl:478
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.ungetCnt(1)
+			{
+				lex.top--
+				lex.cs = lex.stack[lex.top]
+				goto _again
+			}
+		}
+		goto st525
 	tr796:
-		// line internal/php8/scanner.rl:477
-		lex.te = (lex.p) + 1
-		{
-			c := lex.data[lex.p]
-			lex.error(fmt.Sprintf("WARNING: Unexpected character in input: '%c' (ASCII=%d)", c, c))
-		}
-		goto st528
-	tr797:
-		// line internal/php8/scanner.rl:474
-		lex.te = (lex.p) + 1
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_ENCAPSED_AND_WHITESPACE
-			lex.ret(2)
-			goto _out
-		}
-		goto st528
-	tr800:
-		// line internal/php8/scanner.rl:475
-		lex.te = (lex.p) + 1
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.ID(int(lex.data[lex.ts]))
-			{
-				(lex.p)++
-				lex.cs = 528
-				goto _out
-			}
-		}
-		goto st528
-	tr804:
-		// line internal/php8/scanner.rl:476
-		lex.te = (lex.p) + 1
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.ID(int(']'))
-			lex.ret(2)
-			goto _out
-		}
-		goto st528
-	tr805:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:474
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_ENCAPSED_AND_WHITESPACE
-			lex.ret(2)
-			goto _out
-		}
-		goto st528
-	tr806:
-		// line internal/php8/scanner.rl:477
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			c := lex.data[lex.p]
-			lex.error(fmt.Sprintf("WARNING: Unexpected character in input: '%c' (ASCII=%d)", c, c))
-		}
-		goto st528
-	tr807:
-		// line internal/php8/scanner.rl:475
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.ID(int(lex.data[lex.ts]))
-			{
-				(lex.p)++
-				lex.cs = 528
-				goto _out
-			}
-		}
-		goto st528
-	tr809:
-		// line internal/php8/scanner.rl:472
+		// line internal/php8/scanner.rl:473
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -24284,27 +24078,13 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_VARIABLE
 			{
 				(lex.p)++
-				lex.cs = 528
+				lex.cs = 525
 				goto _out
 			}
 		}
-		goto st528
-	tr810:
-		// line internal/php8/scanner.rl:471
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.setTokenPosition(tkn)
-			tok = token.T_NUM_STRING
-			{
-				(lex.p)++
-				lex.cs = 528
-				goto _out
-			}
-		}
-		goto st528
-	tr814:
-		// line internal/php8/scanner.rl:473
+		goto st525
+	tr799:
+		// line internal/php8/scanner.rl:476
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -24312,97 +24092,134 @@ func (lex *Lexer) Lex() *token.Token {
 			tok = token.T_STRING
 			{
 				(lex.p)++
-				lex.cs = 528
+				lex.cs = 525
 				goto _out
 			}
 		}
-		goto st528
-	st528:
+		goto st525
+	st525:
 		// line NONE:1
 		lex.ts = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof528
+			goto _test_eof525
 		}
-	st_case_528:
+	st_case_525:
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:22694
+		// line internal/php8/scanner.go:22514
 		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr798
-		case 13:
-			goto tr799
-		case 32:
-			goto tr797
-		case 33:
-			goto tr800
-		case 35:
-			goto tr797
 		case 36:
-			goto st531
-		case 39:
-			goto tr797
-		case 48:
-			goto tr802
-		case 92:
-			goto tr797
-		case 93:
-			goto tr804
+			goto st526
+		case 45:
+			goto tr790
+		case 63:
+			goto tr791
+		case 91:
+			goto tr793
 		case 96:
-			goto tr796
-		case 124:
-			goto tr800
-		case 126:
-			goto tr800
+			goto tr788
 		}
 		switch {
-		case lex.data[(lex.p)] < 37:
-			switch {
-			case lex.data[(lex.p)] < 9:
-				if lex.data[(lex.p)] <= 8 {
-					goto tr796
-				}
-			case lex.data[(lex.p)] > 12:
-				if 14 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 34 {
-					goto tr796
-				}
-			default:
-				goto tr797
+		case lex.data[(lex.p)] < 92:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr788
 			}
-		case lex.data[(lex.p)] > 47:
-			switch {
-			case lex.data[(lex.p)] < 58:
-				if 49 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-					goto tr168
-				}
-			case lex.data[(lex.p)] > 64:
-				switch {
-				case lex.data[(lex.p)] > 94:
-					if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-						goto tr796
-					}
-				case lex.data[(lex.p)] >= 91:
-					goto tr800
-				}
-			default:
-				goto tr800
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr788
 			}
 		default:
-			goto tr800
+			goto tr788
 		}
-		goto st537
-	tr798:
-		// line internal/php8/scanner.rl:38
+		goto st530
+	st526:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof526
+		}
+	st_case_526:
+		if lex.data[(lex.p)] == 96 {
+			goto tr794
+		}
+		switch {
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr794
+			}
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr794
+			}
+		default:
+			goto tr794
+		}
+		goto st527
+	st527:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof527
+		}
+	st_case_527:
+		if lex.data[(lex.p)] == 96 {
+			goto tr796
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr796
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr796
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr796
+			}
+		default:
+			goto tr796
+		}
+		goto st527
+	tr790:
+		// line NONE:1
+		lex.te = (lex.p) + 1
 
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
+		goto st528
+	st528:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof528
 		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
+	st_case_528:
+		// line internal/php8/scanner.go:22597
+		if lex.data[(lex.p)] == 62 {
+			goto st112
 		}
+		goto tr794
+	st112:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof112
+		}
+	st_case_112:
+		if lex.data[(lex.p)] == 96 {
+			goto tr164
+		}
+		switch {
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr164
+			}
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr164
+			}
+		default:
+			goto tr164
+		}
+		goto tr165
+	tr791:
+		// line NONE:1
+		lex.te = (lex.p) + 1
 
 		goto st529
 	st529:
@@ -24410,9 +24227,276 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof529
 		}
 	st_case_529:
-		// line internal/php8/scanner.go:22776
-		goto tr805
-	tr799:
+		// line internal/php8/scanner.go:22633
+		if lex.data[(lex.p)] == 45 {
+			goto st113
+		}
+		goto tr794
+	st113:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof113
+		}
+	st_case_113:
+		if lex.data[(lex.p)] == 62 {
+			goto st114
+		}
+		goto tr164
+	st114:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof114
+		}
+	st_case_114:
+		if lex.data[(lex.p)] == 96 {
+			goto tr164
+		}
+		switch {
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr164
+			}
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr164
+			}
+		default:
+			goto tr164
+		}
+		goto tr167
+	st530:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof530
+		}
+	st_case_530:
+		if lex.data[(lex.p)] == 96 {
+			goto tr799
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr799
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr799
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr799
+			}
+		default:
+			goto tr799
+		}
+		goto st530
+	tr168:
+		// line internal/php8/scanner.rl:482
+		(lex.p) = (lex.te) - 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_NUM_STRING
+			{
+				(lex.p)++
+				lex.cs = 531
+				goto _out
+			}
+		}
+		goto st531
+	tr800:
+		// line internal/php8/scanner.rl:488
+		lex.te = (lex.p) + 1
+		{
+			c := lex.data[lex.p]
+			lex.error(fmt.Sprintf("WARNING: Unexpected character in input: '%c' (ASCII=%d)", c, c))
+		}
+		goto st531
+	tr801:
+		// line internal/php8/scanner.rl:485
+		lex.te = (lex.p) + 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_ENCAPSED_AND_WHITESPACE
+			lex.ret(2)
+			goto _out
+		}
+		goto st531
+	tr804:
+		// line internal/php8/scanner.rl:486
+		lex.te = (lex.p) + 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.ID(int(lex.data[lex.ts]))
+			{
+				(lex.p)++
+				lex.cs = 531
+				goto _out
+			}
+		}
+		goto st531
+	tr808:
+		// line internal/php8/scanner.rl:487
+		lex.te = (lex.p) + 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.ID(int(']'))
+			lex.ret(2)
+			goto _out
+		}
+		goto st531
+	tr809:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:485
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_ENCAPSED_AND_WHITESPACE
+			lex.ret(2)
+			goto _out
+		}
+		goto st531
+	tr810:
+		// line internal/php8/scanner.rl:488
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			c := lex.data[lex.p]
+			lex.error(fmt.Sprintf("WARNING: Unexpected character in input: '%c' (ASCII=%d)", c, c))
+		}
+		goto st531
+	tr811:
+		// line internal/php8/scanner.rl:486
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.ID(int(lex.data[lex.ts]))
+			{
+				(lex.p)++
+				lex.cs = 531
+				goto _out
+			}
+		}
+		goto st531
+	tr813:
+		// line internal/php8/scanner.rl:483
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_VARIABLE
+			{
+				(lex.p)++
+				lex.cs = 531
+				goto _out
+			}
+		}
+		goto st531
+	tr814:
+		// line internal/php8/scanner.rl:482
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_NUM_STRING
+			{
+				(lex.p)++
+				lex.cs = 531
+				goto _out
+			}
+		}
+		goto st531
+	tr819:
+		// line internal/php8/scanner.rl:484
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.T_STRING
+			{
+				(lex.p)++
+				lex.cs = 531
+				goto _out
+			}
+		}
+		goto st531
+	st531:
+		// line NONE:1
+		lex.ts = 0
+
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof531
+		}
+	st_case_531:
+		// line NONE:1
+		lex.ts = (lex.p)
+
+		// line internal/php8/scanner.go:22774
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr802
+		case 13:
+			goto tr803
+		case 32:
+			goto tr801
+		case 33:
+			goto tr804
+		case 35:
+			goto tr801
+		case 36:
+			goto st534
+		case 39:
+			goto tr801
+		case 48:
+			goto tr806
+		case 92:
+			goto tr801
+		case 93:
+			goto tr808
+		case 96:
+			goto tr800
+		case 124:
+			goto tr804
+		case 126:
+			goto tr804
+		}
+		switch {
+		case lex.data[(lex.p)] < 37:
+			switch {
+			case lex.data[(lex.p)] < 9:
+				if lex.data[(lex.p)] <= 8 {
+					goto tr800
+				}
+			case lex.data[(lex.p)] > 12:
+				if 14 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 34 {
+					goto tr800
+				}
+			default:
+				goto tr801
+			}
+		case lex.data[(lex.p)] > 47:
+			switch {
+			case lex.data[(lex.p)] < 58:
+				if 49 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+					goto tr169
+				}
+			case lex.data[(lex.p)] > 64:
+				switch {
+				case lex.data[(lex.p)] > 94:
+					if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+						goto tr800
+					}
+				case lex.data[(lex.p)] >= 91:
+					goto tr804
+				}
+			default:
+				goto tr804
+			}
+		default:
+			goto tr804
+		}
+		goto st541
+	tr802:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -24423,67 +24507,24 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st530
-	st530:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof530
-		}
-	st_case_530:
-		// line internal/php8/scanner.go:22795
-		if lex.data[(lex.p)] == 10 {
-			goto tr798
-		}
-		goto tr806
-	st531:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof531
-		}
-	st_case_531:
-		if lex.data[(lex.p)] == 96 {
-			goto tr807
-		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr807
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr807
-			}
-		default:
-			goto tr807
-		}
 		goto st532
 	st532:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof532
 		}
 	st_case_532:
-		if lex.data[(lex.p)] == 96 {
-			goto tr809
+		// line internal/php8/scanner.go:22856
+		goto tr809
+	tr803:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
 		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr809
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr809
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr809
-			}
-		default:
-			goto tr809
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
 		}
-		goto st532
-	tr802:
-		// line NONE:1
-		lex.te = (lex.p) + 1
 
 		goto st533
 	st533:
@@ -24491,92 +24532,59 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof533
 		}
 	st_case_533:
-		// line internal/php8/scanner.go:22857
-		switch lex.data[(lex.p)] {
-		case 95:
-			goto st114
-		case 98:
-			goto st115
-		case 120:
-			goto st116
-		}
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto tr168
+		// line internal/php8/scanner.go:22875
+		if lex.data[(lex.p)] == 10 {
+			goto tr802
 		}
 		goto tr810
-	tr168:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st534
 	st534:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof534
 		}
 	st_case_534:
-		// line internal/php8/scanner.go:22880
-		if lex.data[(lex.p)] == 95 {
-			goto st114
+		if lex.data[(lex.p)] == 96 {
+			goto tr811
 		}
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto tr168
+		switch {
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr811
+			}
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr811
+			}
+		default:
+			goto tr811
 		}
-		goto tr810
-	st114:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof114
-		}
-	st_case_114:
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto tr168
-		}
-		goto tr167
-	st115:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof115
-		}
-	st_case_115:
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 49 {
-			goto tr169
-		}
-		goto tr167
-	tr169:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
 		goto st535
 	st535:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof535
 		}
 	st_case_535:
-		// line internal/php8/scanner.go:22916
-		if lex.data[(lex.p)] == 95 {
-			goto st115
+		if lex.data[(lex.p)] == 96 {
+			goto tr813
 		}
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 49 {
-			goto tr169
-		}
-		goto tr810
-	st116:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof116
-		}
-	st_case_116:
 		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr170
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr813
 			}
-		case lex.data[(lex.p)] > 70:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
-				goto tr170
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr813
+				}
+			case lex.data[(lex.p)] >= 91:
+				goto tr813
 			}
 		default:
-			goto tr170
+			goto tr813
 		}
-		goto tr167
-	tr170:
+		goto st535
+	tr806:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -24586,121 +24594,91 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof536
 		}
 	st_case_536:
-		// line internal/php8/scanner.go:22952
-		if lex.data[(lex.p)] == 95 {
+		// line internal/php8/scanner.go:22937
+		switch lex.data[(lex.p)] {
+		case 66:
 			goto st116
+		case 79:
+			goto st117
+		case 88:
+			goto st118
+		case 95:
+			goto st115
+		case 98:
+			goto st116
+		case 111:
+			goto st117
+		case 120:
+			goto st118
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr170
-			}
-		case lex.data[(lex.p)] > 70:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
-				goto tr170
-			}
-		default:
-			goto tr170
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+			goto tr169
 		}
-		goto tr810
+		goto tr814
+	tr169:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st537
 	st537:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof537
 		}
 	st_case_537:
-		if lex.data[(lex.p)] == 96 {
-			goto tr814
+		// line internal/php8/scanner.go:22968
+		if lex.data[(lex.p)] == 95 {
+			goto st115
 		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr814
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr814
-				}
-			case lex.data[(lex.p)] >= 91:
-				goto tr814
-			}
-		default:
-			goto tr814
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+			goto tr169
 		}
-		goto st537
-	tr171:
-		lex.cs = 538
-		// line internal/php8/scanner.rl:485
-		(lex.p) = (lex.te) - 1
-		{
-			lex.ungetCnt(1)
-			lex.cs = 131
+		goto tr814
+	st115:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof115
 		}
-		goto _again
-	tr173:
-		lex.cs = 538
-		// line internal/php8/scanner.rl:484
-		lex.te = (lex.p) + 1
-		{
-			lex.ungetCnt(1)
-			lex.setTokenPosition(tkn)
-			tok = token.T_STRING_VARNAME
-			lex.cs = 131
-			{
-				(lex.p)++
-				goto _out
-			}
+	st_case_115:
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+			goto tr169
 		}
-		goto _again
-	tr815:
-		lex.cs = 538
-		// line internal/php8/scanner.rl:485
-		lex.te = (lex.p) + 1
-		{
-			lex.ungetCnt(1)
-			lex.cs = 131
+		goto tr168
+	st116:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof116
 		}
-		goto _again
-	tr817:
-		lex.cs = 538
-		// line internal/php8/scanner.rl:485
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.ungetCnt(1)
-			lex.cs = 131
+	st_case_116:
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 49 {
+			goto tr170
 		}
-		goto _again
-	st538:
+		goto tr168
+	tr170:
 		// line NONE:1
-		lex.ts = 0
+		lex.te = (lex.p) + 1
 
+		goto st538
+	st538:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof538
 		}
 	st_case_538:
-		// line NONE:1
-		lex.ts = (lex.p)
-
-		// line internal/php8/scanner.go:23031
-		if lex.data[(lex.p)] == 96 {
-			goto tr815
+		// line internal/php8/scanner.go:23004
+		if lex.data[(lex.p)] == 95 {
+			goto st116
 		}
-		switch {
-		case lex.data[(lex.p)] < 91:
-			if lex.data[(lex.p)] <= 64 {
-				goto tr815
-			}
-		case lex.data[(lex.p)] > 94:
-			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-				goto tr815
-			}
-		default:
-			goto tr815
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 49 {
+			goto tr170
 		}
-		goto tr816
-	tr816:
+		goto tr814
+	st117:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof117
+		}
+	st_case_117:
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 56 {
+			goto tr171
+		}
+		goto tr168
+	tr171:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -24710,274 +24688,159 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof539
 		}
 	st_case_539:
-		// line internal/php8/scanner.go:23058
-		switch lex.data[(lex.p)] {
-		case 91:
-			goto tr173
-		case 96:
-			goto tr817
-		case 125:
-			goto tr173
+		// line internal/php8/scanner.go:23031
+		if lex.data[(lex.p)] == 95 {
+			goto st117
 		}
-		switch {
-		case lex.data[(lex.p)] < 58:
-			if lex.data[(lex.p)] <= 47 {
-				goto tr817
-			}
-		case lex.data[(lex.p)] > 64:
-			switch {
-			case lex.data[(lex.p)] > 94:
-				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr817
-				}
-			case lex.data[(lex.p)] >= 92:
-				goto tr817
-			}
-		default:
-			goto tr817
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 56 {
+			goto tr171
 		}
-		goto st117
-	st117:
+		goto tr814
+	st118:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof117
+			goto _test_eof118
 		}
-	st_case_117:
-		switch lex.data[(lex.p)] {
-		case 91:
-			goto tr173
-		case 96:
-			goto tr171
-		case 125:
-			goto tr173
+	st_case_118:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr172
+			}
+		case lex.data[(lex.p)] > 70:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
+				goto tr172
+			}
+		default:
+			goto tr172
+		}
+		goto tr168
+	tr172:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st540
+	st540:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof540
+		}
+	st_case_540:
+		// line internal/php8/scanner.go:23067
+		if lex.data[(lex.p)] == 95 {
+			goto st118
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr172
+			}
+		case lex.data[(lex.p)] > 70:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
+				goto tr172
+			}
+		default:
+			goto tr172
+		}
+		goto tr814
+	st541:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof541
+		}
+	st_case_541:
+		if lex.data[(lex.p)] == 96 {
+			goto tr819
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			if lex.data[(lex.p)] <= 47 {
-				goto tr171
+				goto tr819
 			}
 		case lex.data[(lex.p)] > 64:
 			switch {
 			case lex.data[(lex.p)] > 94:
 				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
-					goto tr171
+					goto tr819
 				}
-			case lex.data[(lex.p)] >= 92:
-				goto tr171
+			case lex.data[(lex.p)] >= 91:
+				goto tr819
 			}
 		default:
-			goto tr171
+			goto tr819
 		}
-		goto st117
-	tr174:
-		// line internal/php8/scanner.rl:489
+		goto st541
+	tr173:
+		lex.cs = 542
+		// line internal/php8/scanner.rl:496
 		(lex.p) = (lex.te) - 1
 		{
-			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
+			lex.ungetCnt(1)
+			lex.cs = 133
 		}
-		goto st540
-	tr818:
-		lex.cs = 540
-		// line internal/php8/scanner.rl:491
+		goto _again
+	tr175:
+		lex.cs = 542
+		// line internal/php8/scanner.rl:495
 		lex.te = (lex.p) + 1
 		{
 			lex.ungetCnt(1)
-			lex.cs = 131
-		}
-		goto _again
-	tr821:
-		lex.cs = 540
-		// line internal/php8/scanner.rl:490
-		lex.te = (lex.p) + 1
-		{
 			lex.setTokenPosition(tkn)
-			tok = token.ID(int('('))
-			lex.cs = 544
+			tok = token.T_STRING_VARNAME
+			lex.cs = 133
 			{
 				(lex.p)++
 				goto _out
 			}
 		}
 		goto _again
+	tr820:
+		lex.cs = 542
+		// line internal/php8/scanner.rl:496
+		lex.te = (lex.p) + 1
+		{
+			lex.ungetCnt(1)
+			lex.cs = 133
+		}
+		goto _again
 	tr822:
-		// line internal/php8/scanner.rl:489
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
-		}
-		goto st540
-	tr824:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:489
-		lex.te = (lex.p)
-		(lex.p)--
-		{
-			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
-		}
-		goto st540
-	tr828:
-		lex.cs = 540
-		// line internal/php8/scanner.rl:491
+		lex.cs = 542
+		// line internal/php8/scanner.rl:496
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.ungetCnt(1)
-			lex.cs = 131
+			lex.cs = 133
 		}
 		goto _again
-	st540:
+	st542:
 		// line NONE:1
 		lex.ts = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof540
-		}
-	st_case_540:
-		// line NONE:1
-		lex.ts = (lex.p)
-
-		// line internal/php8/scanner.go:23165
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr175
-		case 13:
-			goto tr820
-		case 32:
-			goto tr819
-		case 40:
-			goto tr821
-		}
-		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr819
-		}
-		goto tr818
-	tr819:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st541
-	tr825:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:54
-
-		goto st541
-	st541:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof541
-		}
-	st_case_541:
-		// line internal/php8/scanner.go:23197
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr175
-		case 13:
-			goto tr823
-		case 32:
-			goto tr819
-		}
-		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr819
-		}
-		goto tr822
-	tr175:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st542
-	tr826:
-		// line NONE:1
-		lex.te = (lex.p) + 1
-
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st542
-	st542:
-		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof542
 		}
 	st_case_542:
-		// line internal/php8/scanner.go:23247
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr826
-		case 13:
-			goto tr827
-		case 32:
-			goto tr825
-		}
-		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr825
-		}
-		goto tr824
-	tr823:
-		// line internal/php8/scanner.rl:38
+		// line NONE:1
+		lex.ts = (lex.p)
 
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
+		// line internal/php8/scanner.go:23146
+		if lex.data[(lex.p)] == 96 {
+			goto tr820
 		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
+		switch {
+		case lex.data[(lex.p)] < 91:
+			if lex.data[(lex.p)] <= 64 {
+				goto tr820
+			}
+		case lex.data[(lex.p)] > 94:
+			if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+				goto tr820
+			}
+		default:
+			goto tr820
 		}
-
-		goto st118
-	tr827:
-		// line internal/php8/scanner.rl:54
-
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		goto st118
-	st118:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof118
-		}
-	st_case_118:
-		// line internal/php8/scanner.go:23291
-		if lex.data[(lex.p)] == 10 {
-			goto tr175
-		}
-		goto tr174
-	tr820:
-		// line internal/php8/scanner.rl:38
-
-		if lex.data[lex.p] == '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
-
-		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
-			lex.newLines.Append(lex.p + 1)
-		}
+		goto tr821
+	tr821:
+		// line NONE:1
+		lex.te = (lex.p) + 1
 
 		goto st543
 	st543:
@@ -24985,34 +24848,87 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof543
 		}
 	st_case_543:
-		// line internal/php8/scanner.go:23313
-		if lex.data[(lex.p)] == 10 {
+		// line internal/php8/scanner.go:23173
+		switch lex.data[(lex.p)] {
+		case 91:
+			goto tr175
+		case 96:
+			goto tr822
+		case 125:
 			goto tr175
 		}
-		goto tr828
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr822
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr822
+				}
+			case lex.data[(lex.p)] >= 92:
+				goto tr822
+			}
+		default:
+			goto tr822
+		}
+		goto st119
+	st119:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof119
+		}
+	st_case_119:
+		switch lex.data[(lex.p)] {
+		case 91:
+			goto tr175
+		case 96:
+			goto tr173
+		case 125:
+			goto tr175
+		}
+		switch {
+		case lex.data[(lex.p)] < 58:
+			if lex.data[(lex.p)] <= 47 {
+				goto tr173
+			}
+		case lex.data[(lex.p)] > 64:
+			switch {
+			case lex.data[(lex.p)] > 94:
+				if 123 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 127 {
+					goto tr173
+				}
+			case lex.data[(lex.p)] >= 92:
+				goto tr173
+			}
+		default:
+			goto tr173
+		}
+		goto st119
 	tr176:
-		// line internal/php8/scanner.rl:495
+		// line internal/php8/scanner.rl:500
 		(lex.p) = (lex.te) - 1
 		{
 			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
 		goto st544
-	tr829:
+	tr823:
 		lex.cs = 544
-		// line internal/php8/scanner.rl:497
+		// line internal/php8/scanner.rl:502
 		lex.te = (lex.p) + 1
 		{
 			lex.ungetCnt(1)
-			lex.cs = 131
+			lex.cs = 133
 		}
 		goto _again
-	tr832:
+	tr826:
 		lex.cs = 544
-		// line internal/php8/scanner.rl:496
+		// line internal/php8/scanner.rl:501
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
-			tok = token.ID(int(')'))
+			tok = token.ID(int('('))
 			lex.cs = 548
 			{
 				(lex.p)++
@@ -25020,32 +24936,32 @@ func (lex *Lexer) Lex() *token.Token {
 			}
 		}
 		goto _again
-	tr833:
-		// line internal/php8/scanner.rl:495
+	tr827:
+		// line internal/php8/scanner.rl:500
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
 		goto st544
-	tr835:
+	tr829:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:495
+		// line internal/php8/scanner.rl:500
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
 		goto st544
-	tr839:
+	tr833:
 		lex.cs = 544
-		// line internal/php8/scanner.rl:497
+		// line internal/php8/scanner.rl:502
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.ungetCnt(1)
-			lex.cs = 131
+			lex.cs = 133
 		}
 		goto _again
 	st544:
@@ -25059,27 +24975,27 @@ func (lex *Lexer) Lex() *token.Token {
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:23367
+		// line internal/php8/scanner.go:23280
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr177
 		case 13:
-			goto tr831
+			goto tr825
 		case 32:
-			goto tr830
-		case 41:
-			goto tr832
+			goto tr824
+		case 40:
+			goto tr826
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr830
+			goto tr824
 		}
-		goto tr829
-	tr830:
+		goto tr823
+	tr824:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
 		goto st545
-	tr836:
+	tr830:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -25091,19 +25007,19 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof545
 		}
 	st_case_545:
-		// line internal/php8/scanner.go:23399
+		// line internal/php8/scanner.go:23312
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr177
 		case 13:
-			goto tr834
+			goto tr828
 		case 32:
-			goto tr830
+			goto tr824
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr830
+			goto tr824
 		}
-		goto tr833
+		goto tr827
 	tr177:
 		// line NONE:1
 		lex.te = (lex.p) + 1
@@ -25119,7 +25035,7 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 
 		goto st546
-	tr837:
+	tr831:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -25141,20 +25057,20 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof546
 		}
 	st_case_546:
-		// line internal/php8/scanner.go:23449
+		// line internal/php8/scanner.go:23362
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr837
+			goto tr831
 		case 13:
-			goto tr838
+			goto tr832
 		case 32:
-			goto tr836
+			goto tr830
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr836
+			goto tr830
 		}
-		goto tr835
-	tr834:
+		goto tr829
+	tr828:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -25165,8 +25081,8 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st119
-	tr838:
+		goto st120
+	tr832:
 		// line internal/php8/scanner.rl:54
 
 		// line internal/php8/scanner.rl:38
@@ -25179,18 +25095,18 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st119
-	st119:
+		goto st120
+	st120:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof119
+			goto _test_eof120
 		}
-	st_case_119:
-		// line internal/php8/scanner.go:23493
+	st_case_120:
+		// line internal/php8/scanner.go:23406
 		if lex.data[(lex.p)] == 10 {
 			goto tr177
 		}
 		goto tr176
-	tr831:
+	tr825:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -25207,34 +25123,34 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof547
 		}
 	st_case_547:
-		// line internal/php8/scanner.go:23515
+		// line internal/php8/scanner.go:23428
 		if lex.data[(lex.p)] == 10 {
 			goto tr177
 		}
-		goto tr839
+		goto tr833
 	tr178:
-		// line internal/php8/scanner.rl:501
+		// line internal/php8/scanner.rl:506
 		(lex.p) = (lex.te) - 1
 		{
 			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
 		goto st548
-	tr840:
+	tr834:
 		lex.cs = 548
-		// line internal/php8/scanner.rl:503
+		// line internal/php8/scanner.rl:508
 		lex.te = (lex.p) + 1
 		{
 			lex.ungetCnt(1)
-			lex.cs = 131
+			lex.cs = 133
 		}
 		goto _again
-	tr843:
+	tr837:
 		lex.cs = 548
-		// line internal/php8/scanner.rl:502
+		// line internal/php8/scanner.rl:507
 		lex.te = (lex.p) + 1
 		{
 			lex.setTokenPosition(tkn)
-			tok = token.ID(int(';'))
+			tok = token.ID(int(')'))
 			lex.cs = 552
 			{
 				(lex.p)++
@@ -25242,32 +25158,32 @@ func (lex *Lexer) Lex() *token.Token {
 			}
 		}
 		goto _again
-	tr844:
-		// line internal/php8/scanner.rl:501
+	tr838:
+		// line internal/php8/scanner.rl:506
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
 		goto st548
-	tr846:
+	tr840:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:501
+		// line internal/php8/scanner.rl:506
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
 		goto st548
-	tr850:
+	tr844:
 		lex.cs = 548
-		// line internal/php8/scanner.rl:503
+		// line internal/php8/scanner.rl:508
 		lex.te = (lex.p)
 		(lex.p)--
 		{
 			lex.ungetCnt(1)
-			lex.cs = 131
+			lex.cs = 133
 		}
 		goto _again
 	st548:
@@ -25281,27 +25197,27 @@ func (lex *Lexer) Lex() *token.Token {
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:23569
+		// line internal/php8/scanner.go:23482
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr179
 		case 13:
-			goto tr842
+			goto tr836
 		case 32:
-			goto tr841
-		case 59:
-			goto tr843
+			goto tr835
+		case 41:
+			goto tr837
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr841
+			goto tr835
 		}
-		goto tr840
-	tr841:
+		goto tr834
+	tr835:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
 		goto st549
-	tr847:
+	tr841:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -25313,19 +25229,19 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof549
 		}
 	st_case_549:
-		// line internal/php8/scanner.go:23601
+		// line internal/php8/scanner.go:23514
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr179
 		case 13:
-			goto tr845
+			goto tr839
 		case 32:
-			goto tr841
+			goto tr835
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr841
+			goto tr835
 		}
-		goto tr844
+		goto tr838
 	tr179:
 		// line NONE:1
 		lex.te = (lex.p) + 1
@@ -25341,7 +25257,7 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 
 		goto st550
-	tr848:
+	tr842:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -25363,20 +25279,20 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof550
 		}
 	st_case_550:
-		// line internal/php8/scanner.go:23651
+		// line internal/php8/scanner.go:23564
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr848
+			goto tr842
 		case 13:
-			goto tr849
+			goto tr843
 		case 32:
-			goto tr847
+			goto tr841
 		}
 		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
-			goto tr847
+			goto tr841
 		}
-		goto tr846
-	tr845:
+		goto tr840
+	tr839:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -25387,8 +25303,8 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st120
-	tr849:
+		goto st121
+	tr843:
 		// line internal/php8/scanner.rl:54
 
 		// line internal/php8/scanner.rl:38
@@ -25401,18 +25317,18 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st120
-	st120:
+		goto st121
+	st121:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof120
+			goto _test_eof121
 		}
-	st_case_120:
-		// line internal/php8/scanner.go:23695
+	st_case_121:
+		// line internal/php8/scanner.go:23608
 		if lex.data[(lex.p)] == 10 {
 			goto tr179
 		}
 		goto tr178
-	tr842:
+	tr836:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -25429,52 +25345,72 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof551
 		}
 	st_case_551:
-		// line internal/php8/scanner.go:23717
+		// line internal/php8/scanner.go:23630
 		if lex.data[(lex.p)] == 10 {
 			goto tr179
 		}
-		goto tr850
-	tr854:
-		// line NONE:1
-		switch lex.act {
-		case 0:
+		goto tr844
+	tr180:
+		// line internal/php8/scanner.rl:512
+		(lex.p) = (lex.te) - 1
+		{
+			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
+		}
+		goto st552
+	tr845:
+		lex.cs = 552
+		// line internal/php8/scanner.rl:514
+		lex.te = (lex.p) + 1
+		{
+			lex.ungetCnt(1)
+			lex.cs = 133
+		}
+		goto _again
+	tr848:
+		lex.cs = 552
+		// line internal/php8/scanner.rl:513
+		lex.te = (lex.p) + 1
+		{
+			lex.setTokenPosition(tkn)
+			tok = token.ID(int(';'))
+			lex.cs = 556
 			{
-				{
-					goto st0
-				}
-			}
-		case 197:
-			{
-				(lex.p) = (lex.te) - 1
-				lex.addFreeFloatingToken(tkn, token.T_HALT_COMPILER, lex.ts, lex.te)
+				(lex.p)++
+				goto _out
 			}
 		}
-
+		goto _again
+	tr849:
+		// line internal/php8/scanner.rl:512
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
+		}
 		goto st552
-	tr855:
+	tr851:
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:507
+		// line internal/php8/scanner.rl:512
 		lex.te = (lex.p)
 		(lex.p)--
 		{
-			lex.addFreeFloatingToken(tkn, token.T_HALT_COMPILER, lex.ts, lex.te)
+			lex.addFreeFloatingToken(tkn, token.T_WHITESPACE, lex.ts, lex.te)
 		}
 		goto st552
-	tr859:
-		// line internal/php8/scanner.rl:507
+	tr855:
+		lex.cs = 552
+		// line internal/php8/scanner.rl:514
 		lex.te = (lex.p)
 		(lex.p)--
 		{
-			lex.addFreeFloatingToken(tkn, token.T_HALT_COMPILER, lex.ts, lex.te)
+			lex.ungetCnt(1)
+			lex.cs = 133
 		}
-		goto st552
+		goto _again
 	st552:
 		// line NONE:1
 		lex.ts = 0
-
-		// line NONE:1
-		lex.act = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof552
@@ -25483,44 +25419,55 @@ func (lex *Lexer) Lex() *token.Token {
 		// line NONE:1
 		lex.ts = (lex.p)
 
-		// line internal/php8/scanner.go:23761
+		// line internal/php8/scanner.go:23684
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr852
+			goto tr181
 		case 13:
-			goto tr853
+			goto tr847
+		case 32:
+			goto tr846
+		case 59:
+			goto tr848
 		}
-		goto tr851
-	tr851:
+		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
+			goto tr846
+		}
+		goto tr845
+	tr846:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
-		// line internal/php8/scanner.rl:507
-		lex.act = 197
 		goto st553
-	tr856:
+	tr852:
 		// line NONE:1
 		lex.te = (lex.p) + 1
 
 		// line internal/php8/scanner.rl:54
 
-		// line internal/php8/scanner.rl:507
-		lex.act = 197
 		goto st553
 	st553:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof553
 		}
 	st_case_553:
-		// line internal/php8/scanner.go:23790
+		// line internal/php8/scanner.go:23716
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr852
+			goto tr181
 		case 13:
-			goto tr853
+			goto tr850
+		case 32:
+			goto tr846
 		}
-		goto tr851
-	tr852:
+		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
+			goto tr846
+		}
+		goto tr849
+	tr181:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -25532,7 +25479,10 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 
 		goto st554
-	tr857:
+	tr853:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
 		// line internal/php8/scanner.rl:54
 
 		// line internal/php8/scanner.rl:38
@@ -25551,15 +25501,20 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof554
 		}
 	st_case_554:
-		// line internal/php8/scanner.go:23829
+		// line internal/php8/scanner.go:23766
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr857
+			goto tr853
 		case 13:
-			goto tr858
+			goto tr854
+		case 32:
+			goto tr852
 		}
-		goto tr856
-	tr853:
+		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 12 {
+			goto tr852
+		}
+		goto tr851
+	tr850:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -25570,10 +25525,32 @@ func (lex *Lexer) Lex() *token.Token {
 			lex.newLines.Append(lex.p + 1)
 		}
 
-		goto st555
-	tr858:
+		goto st122
+	tr854:
 		// line internal/php8/scanner.rl:54
 
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st122
+	st122:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof122
+		}
+	st_case_122:
+		// line internal/php8/scanner.go:23810
+		if lex.data[(lex.p)] == 10 {
+			goto tr181
+		}
+		goto tr180
+	tr847:
 		// line internal/php8/scanner.rl:38
 
 		if lex.data[lex.p] == '\n' {
@@ -25590,29 +25567,184 @@ func (lex *Lexer) Lex() *token.Token {
 			goto _test_eof555
 		}
 	st_case_555:
-		// line internal/php8/scanner.go:23868
+		// line internal/php8/scanner.go:23832
+		if lex.data[(lex.p)] == 10 {
+			goto tr181
+		}
+		goto tr855
+	tr859:
+		// line NONE:1
+		switch lex.act {
+		case 0:
+			{
+				{
+					goto st0
+				}
+			}
+		case 198:
+			{
+				(lex.p) = (lex.te) - 1
+				lex.addFreeFloatingToken(tkn, token.T_HALT_COMPILER, lex.ts, lex.te)
+			}
+		}
+
+		goto st556
+	tr860:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:518
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.addFreeFloatingToken(tkn, token.T_HALT_COMPILER, lex.ts, lex.te)
+		}
+		goto st556
+	tr864:
+		// line internal/php8/scanner.rl:518
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.addFreeFloatingToken(tkn, token.T_HALT_COMPILER, lex.ts, lex.te)
+		}
+		goto st556
+	st556:
+		// line NONE:1
+		lex.ts = 0
+
+		// line NONE:1
+		lex.act = 0
+
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof556
+		}
+	st_case_556:
+		// line NONE:1
+		lex.ts = (lex.p)
+
+		// line internal/php8/scanner.go:23876
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr852
+			goto tr857
 		case 13:
-			goto tr853
+			goto tr858
 		}
-		goto tr851
+		goto tr856
+	tr856:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:518
+		lex.act = 198
+		goto st557
+	tr861:
+		// line NONE:1
+		lex.te = (lex.p) + 1
+
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:518
+		lex.act = 198
+		goto st557
+	st557:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof557
+		}
+	st_case_557:
+		// line internal/php8/scanner.go:23905
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr857
+		case 13:
+			goto tr858
+		}
+		goto tr856
+	tr857:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st558
+	tr862:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st558
+	st558:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof558
+		}
+	st_case_558:
+		// line internal/php8/scanner.go:23944
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr862
+		case 13:
+			goto tr863
+		}
+		goto tr861
+	tr858:
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st559
+	tr863:
+		// line internal/php8/scanner.rl:54
+
+		// line internal/php8/scanner.rl:38
+
+		if lex.data[lex.p] == '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		if lex.data[lex.p] == '\r' && lex.data[lex.p+1] != '\n' {
+			lex.newLines.Append(lex.p + 1)
+		}
+
+		goto st559
+	st559:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof559
+		}
+	st_case_559:
+		// line internal/php8/scanner.go:23983
+		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr857
+		case 13:
+			goto tr858
+		}
+		goto tr856
 	st_out:
-	_test_eof121:
-		lex.cs = 121
-		goto _test_eof
-	_test_eof122:
-		lex.cs = 122
-		goto _test_eof
-	_test_eof1:
-		lex.cs = 1
-		goto _test_eof
 	_test_eof123:
 		lex.cs = 123
 		goto _test_eof
 	_test_eof124:
 		lex.cs = 124
+		goto _test_eof
+	_test_eof1:
+		lex.cs = 1
 		goto _test_eof
 	_test_eof125:
 		lex.cs = 125
@@ -25629,6 +25761,12 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof129:
 		lex.cs = 129
 		goto _test_eof
+	_test_eof130:
+		lex.cs = 130
+		goto _test_eof
+	_test_eof131:
+		lex.cs = 131
+		goto _test_eof
 	_test_eof2:
 		lex.cs = 2
 		goto _test_eof
@@ -25638,23 +25776,14 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof4:
 		lex.cs = 4
 		goto _test_eof
-	_test_eof130:
-		lex.cs = 130
+	_test_eof132:
+		lex.cs = 132
 		goto _test_eof
 	_test_eof5:
 		lex.cs = 5
 		goto _test_eof
-	_test_eof131:
-		lex.cs = 131
-		goto _test_eof
-	_test_eof132:
-		lex.cs = 132
-		goto _test_eof
 	_test_eof133:
 		lex.cs = 133
-		goto _test_eof
-	_test_eof6:
-		lex.cs = 6
 		goto _test_eof
 	_test_eof134:
 		lex.cs = 134
@@ -25662,11 +25791,20 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof135:
 		lex.cs = 135
 		goto _test_eof
+	_test_eof6:
+		lex.cs = 6
+		goto _test_eof
 	_test_eof136:
 		lex.cs = 136
 		goto _test_eof
 	_test_eof137:
 		lex.cs = 137
+		goto _test_eof
+	_test_eof138:
+		lex.cs = 138
+		goto _test_eof
+	_test_eof139:
+		lex.cs = 139
 		goto _test_eof
 	_test_eof7:
 		lex.cs = 7
@@ -25679,12 +25817,6 @@ func (lex *Lexer) Lex() *token.Token {
 		goto _test_eof
 	_test_eof10:
 		lex.cs = 10
-		goto _test_eof
-	_test_eof138:
-		lex.cs = 138
-		goto _test_eof
-	_test_eof139:
-		lex.cs = 139
 		goto _test_eof
 	_test_eof140:
 		lex.cs = 140
@@ -25704,14 +25836,20 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof145:
 		lex.cs = 145
 		goto _test_eof
+	_test_eof146:
+		lex.cs = 146
+		goto _test_eof
+	_test_eof147:
+		lex.cs = 147
+		goto _test_eof
 	_test_eof11:
 		lex.cs = 11
 		goto _test_eof
 	_test_eof12:
 		lex.cs = 12
 		goto _test_eof
-	_test_eof146:
-		lex.cs = 146
+	_test_eof148:
+		lex.cs = 148
 		goto _test_eof
 	_test_eof13:
 		lex.cs = 13
@@ -25878,12 +26016,6 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof67:
 		lex.cs = 67
 		goto _test_eof
-	_test_eof147:
-		lex.cs = 147
-		goto _test_eof
-	_test_eof148:
-		lex.cs = 148
-		goto _test_eof
 	_test_eof149:
 		lex.cs = 149
 		goto _test_eof
@@ -25893,11 +26025,17 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof151:
 		lex.cs = 151
 		goto _test_eof
+	_test_eof152:
+		lex.cs = 152
+		goto _test_eof
+	_test_eof153:
+		lex.cs = 153
+		goto _test_eof
 	_test_eof68:
 		lex.cs = 68
 		goto _test_eof
-	_test_eof152:
-		lex.cs = 152
+	_test_eof154:
+		lex.cs = 154
 		goto _test_eof
 	_test_eof69:
 		lex.cs = 69
@@ -25905,14 +26043,14 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof70:
 		lex.cs = 70
 		goto _test_eof
-	_test_eof153:
-		lex.cs = 153
+	_test_eof155:
+		lex.cs = 155
 		goto _test_eof
 	_test_eof71:
 		lex.cs = 71
 		goto _test_eof
-	_test_eof154:
-		lex.cs = 154
+	_test_eof156:
+		lex.cs = 156
 		goto _test_eof
 	_test_eof72:
 		lex.cs = 72
@@ -25923,14 +26061,14 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof74:
 		lex.cs = 74
 		goto _test_eof
-	_test_eof155:
-		lex.cs = 155
-		goto _test_eof
-	_test_eof156:
-		lex.cs = 156
-		goto _test_eof
 	_test_eof157:
 		lex.cs = 157
+		goto _test_eof
+	_test_eof158:
+		lex.cs = 158
+		goto _test_eof
+	_test_eof159:
+		lex.cs = 159
 		goto _test_eof
 	_test_eof75:
 		lex.cs = 75
@@ -25938,23 +26076,26 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof76:
 		lex.cs = 76
 		goto _test_eof
-	_test_eof158:
-		lex.cs = 158
+	_test_eof160:
+		lex.cs = 160
 		goto _test_eof
 	_test_eof77:
 		lex.cs = 77
-		goto _test_eof
-	_test_eof159:
-		lex.cs = 159
-		goto _test_eof
-	_test_eof160:
-		lex.cs = 160
 		goto _test_eof
 	_test_eof161:
 		lex.cs = 161
 		goto _test_eof
 	_test_eof78:
 		lex.cs = 78
+		goto _test_eof
+	_test_eof162:
+		lex.cs = 162
+		goto _test_eof
+	_test_eof163:
+		lex.cs = 163
+		goto _test_eof
+	_test_eof164:
+		lex.cs = 164
 		goto _test_eof
 	_test_eof79:
 		lex.cs = 79
@@ -25965,23 +26106,23 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof81:
 		lex.cs = 81
 		goto _test_eof
-	_test_eof162:
-		lex.cs = 162
-		goto _test_eof
-	_test_eof163:
-		lex.cs = 163
-		goto _test_eof
 	_test_eof82:
 		lex.cs = 82
-		goto _test_eof
-	_test_eof164:
-		lex.cs = 164
 		goto _test_eof
 	_test_eof165:
 		lex.cs = 165
 		goto _test_eof
+	_test_eof166:
+		lex.cs = 166
+		goto _test_eof
 	_test_eof83:
 		lex.cs = 83
+		goto _test_eof
+	_test_eof167:
+		lex.cs = 167
+		goto _test_eof
+	_test_eof168:
+		lex.cs = 168
 		goto _test_eof
 	_test_eof84:
 		lex.cs = 84
@@ -25992,11 +26133,11 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof86:
 		lex.cs = 86
 		goto _test_eof
-	_test_eof166:
-		lex.cs = 166
-		goto _test_eof
 	_test_eof87:
 		lex.cs = 87
+		goto _test_eof
+	_test_eof169:
+		lex.cs = 169
 		goto _test_eof
 	_test_eof88:
 		lex.cs = 88
@@ -26007,14 +26148,8 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof90:
 		lex.cs = 90
 		goto _test_eof
-	_test_eof167:
-		lex.cs = 167
-		goto _test_eof
-	_test_eof168:
-		lex.cs = 168
-		goto _test_eof
-	_test_eof169:
-		lex.cs = 169
+	_test_eof91:
+		lex.cs = 91
 		goto _test_eof
 	_test_eof170:
 		lex.cs = 170
@@ -26025,20 +26160,17 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof172:
 		lex.cs = 172
 		goto _test_eof
-	_test_eof91:
-		lex.cs = 91
-		goto _test_eof
 	_test_eof173:
 		lex.cs = 173
 		goto _test_eof
 	_test_eof174:
 		lex.cs = 174
 		goto _test_eof
-	_test_eof92:
-		lex.cs = 92
-		goto _test_eof
 	_test_eof175:
 		lex.cs = 175
+		goto _test_eof
+	_test_eof92:
+		lex.cs = 92
 		goto _test_eof
 	_test_eof176:
 		lex.cs = 176
@@ -26057,6 +26189,9 @@ func (lex *Lexer) Lex() *token.Token {
 		goto _test_eof
 	_test_eof180:
 		lex.cs = 180
+		goto _test_eof
+	_test_eof94:
+		lex.cs = 94
 		goto _test_eof
 	_test_eof181:
 		lex.cs = 181
@@ -26085,12 +26220,6 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof189:
 		lex.cs = 189
 		goto _test_eof
-	_test_eof94:
-		lex.cs = 94
-		goto _test_eof
-	_test_eof95:
-		lex.cs = 95
-		goto _test_eof
 	_test_eof190:
 		lex.cs = 190
 		goto _test_eof
@@ -26099,6 +26228,12 @@ func (lex *Lexer) Lex() *token.Token {
 		goto _test_eof
 	_test_eof192:
 		lex.cs = 192
+		goto _test_eof
+	_test_eof95:
+		lex.cs = 95
+		goto _test_eof
+	_test_eof96:
+		lex.cs = 96
 		goto _test_eof
 	_test_eof193:
 		lex.cs = 193
@@ -26565,9 +26700,6 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof347:
 		lex.cs = 347
 		goto _test_eof
-	_test_eof96:
-		lex.cs = 96
-		goto _test_eof
 	_test_eof348:
 		lex.cs = 348
 		goto _test_eof
@@ -26576,6 +26708,9 @@ func (lex *Lexer) Lex() *token.Token {
 		goto _test_eof
 	_test_eof350:
 		lex.cs = 350
+		goto _test_eof
+	_test_eof97:
+		lex.cs = 97
 		goto _test_eof
 	_test_eof351:
 		lex.cs = 351
@@ -26787,8 +26922,14 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof420:
 		lex.cs = 420
 		goto _test_eof
-	_test_eof97:
-		lex.cs = 97
+	_test_eof421:
+		lex.cs = 421
+		goto _test_eof
+	_test_eof422:
+		lex.cs = 422
+		goto _test_eof
+	_test_eof423:
+		lex.cs = 423
 		goto _test_eof
 	_test_eof98:
 		lex.cs = 98
@@ -26805,23 +26946,17 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof102:
 		lex.cs = 102
 		goto _test_eof
-	_test_eof421:
-		lex.cs = 421
-		goto _test_eof
-	_test_eof422:
-		lex.cs = 422
-		goto _test_eof
 	_test_eof103:
 		lex.cs = 103
-		goto _test_eof
-	_test_eof423:
-		lex.cs = 423
 		goto _test_eof
 	_test_eof424:
 		lex.cs = 424
 		goto _test_eof
 	_test_eof425:
 		lex.cs = 425
+		goto _test_eof
+	_test_eof104:
+		lex.cs = 104
 		goto _test_eof
 	_test_eof426:
 		lex.cs = 426
@@ -27024,9 +27159,6 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof492:
 		lex.cs = 492
 		goto _test_eof
-	_test_eof104:
-		lex.cs = 104
-		goto _test_eof
 	_test_eof493:
 		lex.cs = 493
 		goto _test_eof
@@ -27048,6 +27180,9 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof498:
 		lex.cs = 498
 		goto _test_eof
+	_test_eof106:
+		lex.cs = 106
+		goto _test_eof
 	_test_eof499:
 		lex.cs = 499
 		goto _test_eof
@@ -27060,9 +27195,6 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof502:
 		lex.cs = 502
 		goto _test_eof
-	_test_eof106:
-		lex.cs = 106
-		goto _test_eof
 	_test_eof503:
 		lex.cs = 503
 		goto _test_eof
@@ -27071,6 +27203,9 @@ func (lex *Lexer) Lex() *token.Token {
 		goto _test_eof
 	_test_eof505:
 		lex.cs = 505
+		goto _test_eof
+	_test_eof107:
+		lex.cs = 107
 		goto _test_eof
 	_test_eof506:
 		lex.cs = 506
@@ -27081,12 +27216,6 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof508:
 		lex.cs = 508
 		goto _test_eof
-	_test_eof107:
-		lex.cs = 107
-		goto _test_eof
-	_test_eof108:
-		lex.cs = 108
-		goto _test_eof
 	_test_eof509:
 		lex.cs = 509
 		goto _test_eof
@@ -27095,6 +27224,12 @@ func (lex *Lexer) Lex() *token.Token {
 		goto _test_eof
 	_test_eof511:
 		lex.cs = 511
+		goto _test_eof
+	_test_eof108:
+		lex.cs = 108
+		goto _test_eof
+	_test_eof109:
+		lex.cs = 109
 		goto _test_eof
 	_test_eof512:
 		lex.cs = 512
@@ -27105,12 +27240,6 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof514:
 		lex.cs = 514
 		goto _test_eof
-	_test_eof109:
-		lex.cs = 109
-		goto _test_eof
-	_test_eof110:
-		lex.cs = 110
-		goto _test_eof
 	_test_eof515:
 		lex.cs = 515
 		goto _test_eof
@@ -27119,6 +27248,12 @@ func (lex *Lexer) Lex() *token.Token {
 		goto _test_eof
 	_test_eof517:
 		lex.cs = 517
+		goto _test_eof
+	_test_eof110:
+		lex.cs = 110
+		goto _test_eof
+	_test_eof111:
+		lex.cs = 111
 		goto _test_eof
 	_test_eof518:
 		lex.cs = 518
@@ -27144,17 +27279,8 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof525:
 		lex.cs = 525
 		goto _test_eof
-	_test_eof111:
-		lex.cs = 111
-		goto _test_eof
 	_test_eof526:
 		lex.cs = 526
-		goto _test_eof
-	_test_eof112:
-		lex.cs = 112
-		goto _test_eof
-	_test_eof113:
-		lex.cs = 113
 		goto _test_eof
 	_test_eof527:
 		lex.cs = 527
@@ -27162,8 +27288,17 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof528:
 		lex.cs = 528
 		goto _test_eof
+	_test_eof112:
+		lex.cs = 112
+		goto _test_eof
 	_test_eof529:
 		lex.cs = 529
+		goto _test_eof
+	_test_eof113:
+		lex.cs = 113
+		goto _test_eof
+	_test_eof114:
+		lex.cs = 114
 		goto _test_eof
 	_test_eof530:
 		lex.cs = 530
@@ -27180,17 +27315,8 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof534:
 		lex.cs = 534
 		goto _test_eof
-	_test_eof114:
-		lex.cs = 114
-		goto _test_eof
-	_test_eof115:
-		lex.cs = 115
-		goto _test_eof
 	_test_eof535:
 		lex.cs = 535
-		goto _test_eof
-	_test_eof116:
-		lex.cs = 116
 		goto _test_eof
 	_test_eof536:
 		lex.cs = 536
@@ -27198,14 +27324,23 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof537:
 		lex.cs = 537
 		goto _test_eof
+	_test_eof115:
+		lex.cs = 115
+		goto _test_eof
+	_test_eof116:
+		lex.cs = 116
+		goto _test_eof
 	_test_eof538:
 		lex.cs = 538
+		goto _test_eof
+	_test_eof117:
+		lex.cs = 117
 		goto _test_eof
 	_test_eof539:
 		lex.cs = 539
 		goto _test_eof
-	_test_eof117:
-		lex.cs = 117
+	_test_eof118:
+		lex.cs = 118
 		goto _test_eof
 	_test_eof540:
 		lex.cs = 540
@@ -27216,11 +27351,11 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof542:
 		lex.cs = 542
 		goto _test_eof
-	_test_eof118:
-		lex.cs = 118
-		goto _test_eof
 	_test_eof543:
 		lex.cs = 543
+		goto _test_eof
+	_test_eof119:
+		lex.cs = 119
 		goto _test_eof
 	_test_eof544:
 		lex.cs = 544
@@ -27231,8 +27366,8 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof546:
 		lex.cs = 546
 		goto _test_eof
-	_test_eof119:
-		lex.cs = 119
+	_test_eof120:
+		lex.cs = 120
 		goto _test_eof
 	_test_eof547:
 		lex.cs = 547
@@ -27246,8 +27381,8 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof550:
 		lex.cs = 550
 		goto _test_eof
-	_test_eof120:
-		lex.cs = 120
+	_test_eof121:
+		lex.cs = 121
 		goto _test_eof
 	_test_eof551:
 		lex.cs = 551
@@ -27261,8 +27396,23 @@ func (lex *Lexer) Lex() *token.Token {
 	_test_eof554:
 		lex.cs = 554
 		goto _test_eof
+	_test_eof122:
+		lex.cs = 122
+		goto _test_eof
 	_test_eof555:
 		lex.cs = 555
+		goto _test_eof
+	_test_eof556:
+		lex.cs = 556
+		goto _test_eof
+	_test_eof557:
+		lex.cs = 557
+		goto _test_eof
+	_test_eof558:
+		lex.cs = 558
+		goto _test_eof
+	_test_eof559:
+		lex.cs = 559
 		goto _test_eof
 
 	_test_eof:
@@ -27270,46 +27420,46 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 		if (lex.p) == eof {
 			switch lex.cs {
-			case 122:
-				goto tr182
+			case 124:
+				goto tr184
 			case 1:
 				goto tr0
-			case 123:
-				goto tr183
 			case 125:
-				goto tr188
-			case 126:
-				goto tr190
+				goto tr185
 			case 127:
-				goto tr188
+				goto tr190
 			case 128:
-				goto tr188
+				goto tr192
 			case 129:
-				goto tr196
+				goto tr190
+			case 130:
+				goto tr190
+			case 131:
+				goto tr198
 			case 2:
 				goto tr4
 			case 3:
 				goto tr4
 			case 4:
 				goto tr4
-			case 130:
-				goto tr199
+			case 132:
+				goto tr201
 			case 5:
 				goto tr4
-			case 132:
-				goto tr253
-			case 133:
+			case 134:
 				goto tr255
+			case 135:
+				goto tr257
 			case 6:
 				goto tr10
-			case 134:
-				goto tr259
-			case 135:
-				goto tr260
 			case 136:
-				goto tr262
+				goto tr261
 			case 137:
+				goto tr262
+			case 138:
 				goto tr264
+			case 139:
+				goto tr266
 			case 7:
 				goto tr12
 			case 8:
@@ -27318,28 +27468,28 @@ func (lex *Lexer) Lex() *token.Token {
 				goto tr12
 			case 10:
 				goto tr12
-			case 138:
-				goto tr265
-			case 139:
-				goto tr268
 			case 140:
-				goto tr271
+				goto tr267
 			case 141:
-				goto tr260
+				goto tr270
 			case 142:
-				goto tr276
+				goto tr273
 			case 143:
-				goto tr260
+				goto tr262
 			case 144:
-				goto tr260
+				goto tr278
 			case 145:
-				goto tr259
+				goto tr262
+			case 146:
+				goto tr262
+			case 147:
+				goto tr261
 			case 11:
 				goto tr19
 			case 12:
 				goto tr19
-			case 146:
-				goto tr260
+			case 148:
+				goto tr262
 			case 13:
 				goto tr23
 			case 14:
@@ -27450,894 +27600,902 @@ func (lex *Lexer) Lex() *token.Token {
 				goto tr23
 			case 67:
 				goto tr23
-			case 147:
-				goto tr260
-			case 148:
-				goto tr282
 			case 149:
-				goto tr260
+				goto tr262
 			case 150:
-				goto tr260
+				goto tr284
 			case 151:
-				goto tr260
+				goto tr262
+			case 152:
+				goto tr262
+			case 153:
+				goto tr262
 			case 68:
 				goto tr23
-			case 152:
-				goto tr291
+			case 154:
+				goto tr293
 			case 69:
 				goto tr12
 			case 70:
 				goto tr12
-			case 153:
-				goto tr291
+			case 155:
+				goto tr293
 			case 71:
 				goto tr90
-			case 154:
-				goto tr260
+			case 156:
+				goto tr262
 			case 72:
 				goto tr23
 			case 73:
 				goto tr23
 			case 74:
 				goto tr23
-			case 155:
-				goto tr295
-			case 156:
-				goto tr291
 			case 157:
-				goto tr295
+				goto tr297
+			case 158:
+				goto tr293
+			case 159:
+				goto tr297
 			case 75:
 				goto tr101
 			case 76:
 				goto tr12
-			case 158:
-				goto tr300
+			case 160:
+				goto tr303
 			case 77:
 				goto tr12
-			case 159:
-				goto tr301
-			case 160:
-				goto tr260
 			case 161:
-				goto tr260
+				goto tr304
 			case 78:
-				goto tr23
+				goto tr12
+			case 162:
+				goto tr305
+			case 163:
+				goto tr262
+			case 164:
+				goto tr262
 			case 79:
 				goto tr23
 			case 80:
 				goto tr23
 			case 81:
 				goto tr23
-			case 162:
-				goto tr303
-			case 163:
-				goto tr305
 			case 82:
-				goto tr114
-			case 164:
-				goto tr260
+				goto tr23
 			case 165:
+				goto tr307
+			case 166:
 				goto tr309
 			case 83:
-				goto tr12
+				goto tr115
+			case 167:
+				goto tr262
+			case 168:
+				goto tr313
 			case 84:
 				goto tr12
 			case 85:
 				goto tr12
 			case 86:
 				goto tr12
-			case 166:
-				goto tr311
 			case 87:
 				goto tr12
+			case 169:
+				goto tr315
 			case 88:
 				goto tr12
 			case 89:
 				goto tr12
 			case 90:
 				goto tr12
-			case 167:
-				goto tr312
-			case 168:
-				goto tr260
-			case 169:
-				goto tr316
-			case 170:
-				goto tr260
-			case 171:
-				goto tr320
-			case 172:
-				goto tr260
 			case 91:
-				goto tr23
+				goto tr12
+			case 170:
+				goto tr316
+			case 171:
+				goto tr262
+			case 172:
+				goto tr320
 			case 173:
-				goto tr325
+				goto tr262
 			case 174:
-				goto tr327
-			case 92:
-				goto tr131
+				goto tr324
 			case 175:
-				goto tr328
+				goto tr262
+			case 92:
+				goto tr23
 			case 176:
-				goto tr330
+				goto tr329
 			case 177:
-				goto tr12
+				goto tr331
 			case 93:
-				goto tr12
+				goto tr132
 			case 178:
-				goto tr336
+				goto tr332
 			case 179:
-				goto tr330
+				goto tr334
 			case 180:
-				goto tr330
-			case 181:
-				goto tr330
-			case 182:
-				goto tr330
-			case 183:
-				goto tr330
-			case 184:
-				goto tr330
-			case 185:
-				goto tr330
-			case 186:
-				goto tr330
-			case 187:
-				goto tr330
-			case 188:
-				goto tr330
-			case 189:
-				goto tr330
+				goto tr12
 			case 94:
-				goto tr134
-			case 95:
-				goto tr134
+				goto tr12
+			case 181:
+				goto tr340
+			case 182:
+				goto tr334
+			case 183:
+				goto tr334
+			case 184:
+				goto tr334
+			case 185:
+				goto tr334
+			case 186:
+				goto tr334
+			case 187:
+				goto tr334
+			case 188:
+				goto tr334
+			case 189:
+				goto tr334
 			case 190:
-				goto tr330
+				goto tr334
 			case 191:
-				goto tr330
+				goto tr334
 			case 192:
-				goto tr330
+				goto tr334
+			case 95:
+				goto tr135
+			case 96:
+				goto tr135
 			case 193:
-				goto tr330
+				goto tr334
 			case 194:
-				goto tr330
+				goto tr334
 			case 195:
-				goto tr330
+				goto tr334
 			case 196:
-				goto tr330
+				goto tr334
 			case 197:
-				goto tr330
+				goto tr334
 			case 198:
-				goto tr330
+				goto tr334
 			case 199:
-				goto tr330
+				goto tr334
 			case 200:
-				goto tr330
+				goto tr334
 			case 201:
-				goto tr330
+				goto tr334
 			case 202:
-				goto tr330
+				goto tr334
 			case 203:
-				goto tr330
+				goto tr334
 			case 204:
-				goto tr330
+				goto tr334
 			case 205:
-				goto tr330
+				goto tr334
 			case 206:
-				goto tr330
+				goto tr334
 			case 207:
-				goto tr330
+				goto tr334
 			case 208:
-				goto tr330
+				goto tr334
 			case 209:
-				goto tr330
+				goto tr334
 			case 210:
-				goto tr330
+				goto tr334
 			case 211:
-				goto tr330
+				goto tr334
 			case 212:
-				goto tr330
+				goto tr334
 			case 213:
-				goto tr330
+				goto tr334
 			case 214:
-				goto tr330
+				goto tr334
 			case 215:
-				goto tr330
+				goto tr334
 			case 216:
-				goto tr330
+				goto tr334
 			case 217:
-				goto tr330
+				goto tr334
 			case 218:
-				goto tr330
+				goto tr334
 			case 219:
-				goto tr330
+				goto tr334
 			case 220:
-				goto tr330
+				goto tr334
 			case 221:
-				goto tr330
+				goto tr334
 			case 222:
-				goto tr330
+				goto tr334
 			case 223:
-				goto tr330
+				goto tr334
 			case 224:
-				goto tr330
+				goto tr334
 			case 225:
-				goto tr330
+				goto tr334
 			case 226:
-				goto tr330
+				goto tr334
 			case 227:
-				goto tr330
+				goto tr334
 			case 228:
-				goto tr330
+				goto tr334
 			case 229:
-				goto tr330
+				goto tr334
 			case 230:
-				goto tr330
+				goto tr334
 			case 231:
-				goto tr330
+				goto tr334
 			case 232:
-				goto tr330
+				goto tr334
 			case 233:
-				goto tr330
+				goto tr334
 			case 234:
-				goto tr330
+				goto tr334
 			case 235:
-				goto tr330
+				goto tr334
 			case 236:
-				goto tr330
+				goto tr334
 			case 237:
-				goto tr330
+				goto tr334
 			case 238:
-				goto tr412
+				goto tr334
 			case 239:
-				goto tr330
+				goto tr334
 			case 240:
-				goto tr330
+				goto tr334
 			case 241:
-				goto tr330
+				goto tr416
 			case 242:
-				goto tr330
+				goto tr334
 			case 243:
-				goto tr330
+				goto tr334
 			case 244:
-				goto tr330
+				goto tr334
 			case 245:
-				goto tr330
+				goto tr334
 			case 246:
-				goto tr330
+				goto tr334
 			case 247:
-				goto tr330
+				goto tr334
 			case 248:
-				goto tr330
+				goto tr334
 			case 249:
-				goto tr330
+				goto tr334
 			case 250:
-				goto tr330
+				goto tr334
 			case 251:
-				goto tr330
+				goto tr334
 			case 252:
-				goto tr330
+				goto tr334
 			case 253:
-				goto tr432
+				goto tr334
 			case 254:
-				goto tr330
+				goto tr334
 			case 255:
-				goto tr330
+				goto tr334
 			case 256:
-				goto tr330
+				goto tr436
 			case 257:
-				goto tr330
+				goto tr334
 			case 258:
-				goto tr330
+				goto tr334
 			case 259:
-				goto tr330
+				goto tr334
 			case 260:
-				goto tr330
+				goto tr334
 			case 261:
-				goto tr330
+				goto tr334
 			case 262:
-				goto tr330
+				goto tr334
 			case 263:
-				goto tr330
+				goto tr334
 			case 264:
-				goto tr330
+				goto tr334
 			case 265:
-				goto tr330
+				goto tr334
 			case 266:
-				goto tr330
+				goto tr334
 			case 267:
-				goto tr330
+				goto tr334
 			case 268:
-				goto tr330
+				goto tr334
 			case 269:
-				goto tr330
+				goto tr334
 			case 270:
-				goto tr330
+				goto tr334
 			case 271:
-				goto tr330
+				goto tr334
 			case 272:
-				goto tr330
+				goto tr334
 			case 273:
-				goto tr330
+				goto tr334
 			case 274:
-				goto tr330
+				goto tr334
 			case 275:
-				goto tr330
+				goto tr334
 			case 276:
-				goto tr330
+				goto tr334
 			case 277:
-				goto tr330
+				goto tr334
 			case 278:
-				goto tr330
+				goto tr334
 			case 279:
-				goto tr461
+				goto tr334
 			case 280:
-				goto tr330
+				goto tr334
 			case 281:
-				goto tr330
+				goto tr334
 			case 282:
 				goto tr465
 			case 283:
-				goto tr330
+				goto tr334
 			case 284:
-				goto tr330
+				goto tr334
 			case 285:
-				goto tr330
+				goto tr469
 			case 286:
-				goto tr330
+				goto tr334
 			case 287:
-				goto tr330
+				goto tr334
 			case 288:
-				goto tr330
+				goto tr334
 			case 289:
-				goto tr330
+				goto tr334
 			case 290:
-				goto tr330
+				goto tr334
 			case 291:
-				goto tr330
+				goto tr334
 			case 292:
-				goto tr330
+				goto tr334
 			case 293:
-				goto tr330
+				goto tr334
 			case 294:
-				goto tr330
+				goto tr334
 			case 295:
-				goto tr330
+				goto tr334
 			case 296:
-				goto tr330
+				goto tr334
 			case 297:
-				goto tr330
+				goto tr334
 			case 298:
-				goto tr330
+				goto tr334
 			case 299:
-				goto tr330
+				goto tr334
 			case 300:
-				goto tr330
+				goto tr334
 			case 301:
-				goto tr330
+				goto tr334
 			case 302:
-				goto tr330
+				goto tr334
 			case 303:
-				goto tr330
+				goto tr334
 			case 304:
-				goto tr330
+				goto tr334
 			case 305:
-				goto tr330
+				goto tr334
 			case 306:
-				goto tr330
+				goto tr334
 			case 307:
-				goto tr497
+				goto tr334
 			case 308:
-				goto tr330
+				goto tr334
 			case 309:
-				goto tr330
+				goto tr334
 			case 310:
-				goto tr330
+				goto tr501
 			case 311:
-				goto tr330
+				goto tr334
 			case 312:
-				goto tr330
+				goto tr334
 			case 313:
-				goto tr330
+				goto tr334
 			case 314:
-				goto tr330
+				goto tr334
 			case 315:
-				goto tr330
+				goto tr334
 			case 316:
-				goto tr330
+				goto tr334
 			case 317:
-				goto tr330
+				goto tr334
 			case 318:
-				goto tr330
+				goto tr334
 			case 319:
-				goto tr330
+				goto tr334
 			case 320:
-				goto tr330
+				goto tr334
 			case 321:
-				goto tr330
+				goto tr334
 			case 322:
-				goto tr330
+				goto tr334
 			case 323:
-				goto tr330
+				goto tr334
 			case 324:
-				goto tr330
+				goto tr334
 			case 325:
-				goto tr330
+				goto tr334
 			case 326:
-				goto tr330
+				goto tr334
 			case 327:
-				goto tr330
+				goto tr334
 			case 328:
-				goto tr330
+				goto tr334
 			case 329:
-				goto tr330
+				goto tr334
 			case 330:
-				goto tr330
+				goto tr334
 			case 331:
-				goto tr330
+				goto tr334
 			case 332:
-				goto tr330
+				goto tr334
 			case 333:
-				goto tr330
+				goto tr334
 			case 334:
-				goto tr330
+				goto tr334
 			case 335:
-				goto tr330
+				goto tr334
 			case 336:
-				goto tr330
+				goto tr334
 			case 337:
-				goto tr330
+				goto tr334
 			case 338:
-				goto tr330
+				goto tr334
 			case 339:
-				goto tr330
+				goto tr334
 			case 340:
-				goto tr330
+				goto tr334
 			case 341:
-				goto tr330
+				goto tr334
 			case 342:
-				goto tr330
+				goto tr334
 			case 343:
-				goto tr330
+				goto tr334
 			case 344:
-				goto tr330
+				goto tr334
 			case 345:
-				goto tr330
+				goto tr334
 			case 346:
-				goto tr330
+				goto tr334
 			case 347:
-				goto tr540
-			case 96:
-				goto tr12
+				goto tr334
 			case 348:
-				goto tr542
+				goto tr334
 			case 349:
-				goto tr330
+				goto tr334
 			case 350:
-				goto tr330
-			case 351:
-				goto tr330
-			case 352:
-				goto tr330
-			case 353:
-				goto tr330
-			case 354:
-				goto tr330
-			case 355:
-				goto tr330
-			case 356:
-				goto tr330
-			case 357:
-				goto tr330
-			case 358:
-				goto tr330
-			case 359:
-				goto tr330
-			case 360:
-				goto tr330
-			case 361:
-				goto tr330
-			case 362:
-				goto tr330
-			case 363:
-				goto tr330
-			case 364:
-				goto tr330
-			case 365:
-				goto tr330
-			case 366:
-				goto tr330
-			case 367:
-				goto tr330
-			case 368:
-				goto tr330
-			case 369:
-				goto tr330
-			case 370:
-				goto tr330
-			case 371:
-				goto tr330
-			case 372:
-				goto tr330
-			case 373:
-				goto tr330
-			case 374:
-				goto tr330
-			case 375:
-				goto tr330
-			case 376:
-				goto tr330
-			case 377:
-				goto tr330
-			case 378:
-				goto tr330
-			case 379:
-				goto tr578
-			case 380:
-				goto tr330
-			case 381:
-				goto tr330
-			case 382:
-				goto tr330
-			case 383:
-				goto tr330
-			case 384:
-				goto tr330
-			case 385:
-				goto tr330
-			case 386:
-				goto tr330
-			case 387:
-				goto tr330
-			case 388:
-				goto tr330
-			case 389:
-				goto tr330
-			case 390:
-				goto tr330
-			case 391:
-				goto tr330
-			case 392:
-				goto tr330
-			case 393:
-				goto tr330
-			case 394:
-				goto tr330
-			case 395:
-				goto tr330
-			case 396:
-				goto tr330
-			case 397:
-				goto tr330
-			case 398:
-				goto tr330
-			case 399:
-				goto tr330
-			case 400:
-				goto tr330
-			case 401:
-				goto tr330
-			case 402:
-				goto tr330
-			case 403:
-				goto tr330
-			case 404:
-				goto tr330
-			case 405:
-				goto tr330
-			case 406:
-				goto tr330
-			case 407:
-				goto tr330
-			case 408:
-				goto tr330
-			case 409:
-				goto tr330
-			case 410:
-				goto tr330
-			case 411:
-				goto tr330
-			case 412:
-				goto tr330
-			case 413:
-				goto tr330
-			case 414:
-				goto tr330
-			case 415:
-				goto tr330
-			case 416:
-				goto tr330
-			case 417:
-				goto tr330
-			case 418:
-				goto tr330
-			case 419:
-				goto tr330
-			case 420:
-				goto tr624
+				goto tr544
 			case 97:
-				goto tr137
-			case 98:
-				goto tr137
-			case 99:
-				goto tr137
-			case 100:
-				goto tr137
-			case 101:
-				goto tr137
-			case 102:
-				goto tr137
+				goto tr12
+			case 351:
+				goto tr546
+			case 352:
+				goto tr334
+			case 353:
+				goto tr334
+			case 354:
+				goto tr334
+			case 355:
+				goto tr334
+			case 356:
+				goto tr334
+			case 357:
+				goto tr334
+			case 358:
+				goto tr334
+			case 359:
+				goto tr334
+			case 360:
+				goto tr334
+			case 361:
+				goto tr334
+			case 362:
+				goto tr334
+			case 363:
+				goto tr334
+			case 364:
+				goto tr334
+			case 365:
+				goto tr334
+			case 366:
+				goto tr334
+			case 367:
+				goto tr334
+			case 368:
+				goto tr334
+			case 369:
+				goto tr334
+			case 370:
+				goto tr334
+			case 371:
+				goto tr334
+			case 372:
+				goto tr334
+			case 373:
+				goto tr334
+			case 374:
+				goto tr334
+			case 375:
+				goto tr334
+			case 376:
+				goto tr334
+			case 377:
+				goto tr334
+			case 378:
+				goto tr334
+			case 379:
+				goto tr334
+			case 380:
+				goto tr334
+			case 381:
+				goto tr334
+			case 382:
+				goto tr582
+			case 383:
+				goto tr334
+			case 384:
+				goto tr334
+			case 385:
+				goto tr334
+			case 386:
+				goto tr334
+			case 387:
+				goto tr334
+			case 388:
+				goto tr334
+			case 389:
+				goto tr334
+			case 390:
+				goto tr334
+			case 391:
+				goto tr334
+			case 392:
+				goto tr334
+			case 393:
+				goto tr334
+			case 394:
+				goto tr334
+			case 395:
+				goto tr334
+			case 396:
+				goto tr334
+			case 397:
+				goto tr334
+			case 398:
+				goto tr334
+			case 399:
+				goto tr334
+			case 400:
+				goto tr334
+			case 401:
+				goto tr334
+			case 402:
+				goto tr334
+			case 403:
+				goto tr334
+			case 404:
+				goto tr334
+			case 405:
+				goto tr334
+			case 406:
+				goto tr334
+			case 407:
+				goto tr334
+			case 408:
+				goto tr334
+			case 409:
+				goto tr334
+			case 410:
+				goto tr334
+			case 411:
+				goto tr334
+			case 412:
+				goto tr334
+			case 413:
+				goto tr334
+			case 414:
+				goto tr334
+			case 415:
+				goto tr334
+			case 416:
+				goto tr334
+			case 417:
+				goto tr334
+			case 418:
+				goto tr334
+			case 419:
+				goto tr334
+			case 420:
+				goto tr334
 			case 421:
-				goto tr625
+				goto tr334
 			case 422:
-				goto tr626
-			case 103:
-				goto tr149
+				goto tr334
 			case 423:
-				goto tr260
+				goto tr628
+			case 98:
+				goto tr138
+			case 99:
+				goto tr138
+			case 100:
+				goto tr138
+			case 101:
+				goto tr138
+			case 102:
+				goto tr138
+			case 103:
+				goto tr138
 			case 424:
-				goto tr330
+				goto tr629
 			case 425:
-				goto tr330
-			case 426:
-				goto tr330
-			case 427:
-				goto tr330
-			case 428:
-				goto tr330
-			case 429:
-				goto tr330
-			case 430:
-				goto tr330
-			case 431:
-				goto tr330
-			case 432:
-				goto tr330
-			case 433:
-				goto tr330
-			case 434:
-				goto tr330
-			case 435:
-				goto tr330
-			case 436:
-				goto tr330
-			case 437:
-				goto tr330
-			case 438:
-				goto tr330
-			case 439:
-				goto tr330
-			case 440:
-				goto tr330
-			case 441:
-				goto tr330
-			case 442:
-				goto tr330
-			case 443:
-				goto tr330
-			case 444:
-				goto tr330
-			case 445:
-				goto tr330
-			case 446:
-				goto tr330
-			case 447:
-				goto tr330
-			case 448:
-				goto tr330
-			case 449:
-				goto tr330
-			case 450:
-				goto tr330
-			case 451:
-				goto tr330
-			case 452:
-				goto tr330
-			case 453:
-				goto tr330
-			case 454:
-				goto tr330
-			case 455:
-				goto tr330
-			case 456:
-				goto tr330
-			case 457:
-				goto tr330
-			case 458:
-				goto tr330
-			case 459:
-				goto tr330
-			case 460:
-				goto tr330
-			case 461:
-				goto tr330
-			case 462:
-				goto tr330
-			case 463:
-				goto tr330
-			case 464:
-				goto tr330
-			case 465:
-				goto tr330
-			case 466:
-				goto tr330
-			case 467:
-				goto tr330
-			case 468:
-				goto tr330
-			case 469:
-				goto tr330
-			case 470:
-				goto tr330
-			case 471:
-				goto tr330
-			case 472:
-				goto tr330
-			case 473:
-				goto tr330
-			case 474:
-				goto tr330
-			case 475:
-				goto tr330
-			case 476:
-				goto tr330
-			case 477:
-				goto tr330
-			case 478:
-				goto tr330
-			case 479:
-				goto tr330
-			case 480:
-				goto tr330
-			case 481:
-				goto tr330
-			case 482:
-				goto tr330
-			case 483:
-				goto tr330
-			case 484:
-				goto tr330
-			case 485:
-				goto tr330
-			case 486:
-				goto tr330
-			case 487:
-				goto tr330
-			case 488:
-				goto tr330
-			case 489:
-				goto tr260
-			case 491:
-				goto tr710
-			case 492:
-				goto tr712
+				goto tr630
 			case 104:
-				goto tr151
-			case 493:
-				goto tr716
+				goto tr150
+			case 426:
+				goto tr262
+			case 427:
+				goto tr334
+			case 428:
+				goto tr334
+			case 429:
+				goto tr334
+			case 430:
+				goto tr334
+			case 431:
+				goto tr334
+			case 432:
+				goto tr334
+			case 433:
+				goto tr334
+			case 434:
+				goto tr334
+			case 435:
+				goto tr334
+			case 436:
+				goto tr334
+			case 437:
+				goto tr334
+			case 438:
+				goto tr334
+			case 439:
+				goto tr334
+			case 440:
+				goto tr334
+			case 441:
+				goto tr334
+			case 442:
+				goto tr334
+			case 443:
+				goto tr334
+			case 444:
+				goto tr334
+			case 445:
+				goto tr334
+			case 446:
+				goto tr334
+			case 447:
+				goto tr334
+			case 448:
+				goto tr334
+			case 449:
+				goto tr334
+			case 450:
+				goto tr334
+			case 451:
+				goto tr334
+			case 452:
+				goto tr334
+			case 453:
+				goto tr334
+			case 454:
+				goto tr334
+			case 455:
+				goto tr334
+			case 456:
+				goto tr334
+			case 457:
+				goto tr334
+			case 458:
+				goto tr334
+			case 459:
+				goto tr334
+			case 460:
+				goto tr334
+			case 461:
+				goto tr334
+			case 462:
+				goto tr334
+			case 463:
+				goto tr334
+			case 464:
+				goto tr334
+			case 465:
+				goto tr334
+			case 466:
+				goto tr334
+			case 467:
+				goto tr334
+			case 468:
+				goto tr334
+			case 469:
+				goto tr334
+			case 470:
+				goto tr334
+			case 471:
+				goto tr334
+			case 472:
+				goto tr334
+			case 473:
+				goto tr334
+			case 474:
+				goto tr334
+			case 475:
+				goto tr334
+			case 476:
+				goto tr334
+			case 477:
+				goto tr334
+			case 478:
+				goto tr334
+			case 479:
+				goto tr334
+			case 480:
+				goto tr334
+			case 481:
+				goto tr334
+			case 482:
+				goto tr334
+			case 483:
+				goto tr334
+			case 484:
+				goto tr334
+			case 485:
+				goto tr334
+			case 486:
+				goto tr334
+			case 487:
+				goto tr334
+			case 488:
+				goto tr334
+			case 489:
+				goto tr334
+			case 490:
+				goto tr334
+			case 491:
+				goto tr334
+			case 492:
+				goto tr262
 			case 494:
-				goto tr716
+				goto tr714
 			case 495:
 				goto tr716
 			case 105:
-				goto tr153
+				goto tr152
 			case 496:
-				goto tr719
+				goto tr720
+			case 497:
+				goto tr720
 			case 498:
-				goto tr723
+				goto tr720
+			case 106:
+				goto tr154
 			case 499:
-				goto tr724
-			case 500:
-				goto tr728
+				goto tr723
+			case 501:
+				goto tr727
 			case 502:
-				goto tr736
+				goto tr728
 			case 503:
-				goto tr738
-			case 504:
-				goto tr739
+				goto tr732
 			case 505:
-				goto tr743
+				goto tr740
 			case 506:
-				goto tr736
+				goto tr742
 			case 507:
 				goto tr743
+			case 508:
+				goto tr747
 			case 509:
-				goto tr755
+				goto tr740
 			case 510:
-				goto tr756
-			case 511:
-				goto tr760
+				goto tr747
 			case 512:
-				goto tr760
+				goto tr759
 			case 513:
 				goto tr760
+			case 514:
+				goto tr764
 			case 515:
-				goto tr773
+				goto tr764
 			case 516:
-				goto tr774
-			case 517:
-				goto tr778
+				goto tr764
 			case 518:
-				goto tr778
+				goto tr777
 			case 519:
 				goto tr778
+			case 520:
+				goto tr782
 			case 521:
-				goto tr783
-			case 523:
-				goto tr790
+				goto tr782
+			case 522:
+				goto tr782
 			case 524:
-				goto tr792
-			case 525:
-				goto tr790
-			case 111:
-				goto tr163
+				goto tr787
 			case 526:
-				goto tr790
-			case 112:
-				goto tr163
-			case 113:
-				goto tr163
+				goto tr794
 			case 527:
-				goto tr795
+				goto tr796
+			case 528:
+				goto tr794
+			case 112:
+				goto tr164
 			case 529:
-				goto tr805
+				goto tr794
+			case 113:
+				goto tr164
+			case 114:
+				goto tr164
 			case 530:
-				goto tr806
-			case 531:
-				goto tr807
+				goto tr799
 			case 532:
 				goto tr809
 			case 533:
 				goto tr810
 			case 534:
-				goto tr810
-			case 114:
-				goto tr167
-			case 115:
-				goto tr167
+				goto tr811
 			case 535:
-				goto tr810
-			case 116:
-				goto tr167
+				goto tr813
 			case 536:
-				goto tr810
+				goto tr814
 			case 537:
 				goto tr814
-			case 539:
-				goto tr817
+			case 115:
+				goto tr168
+			case 116:
+				goto tr168
+			case 538:
+				goto tr814
 			case 117:
-				goto tr171
-			case 541:
-				goto tr822
-			case 542:
-				goto tr824
+				goto tr168
+			case 539:
+				goto tr814
 			case 118:
-				goto tr174
+				goto tr168
+			case 540:
+				goto tr814
+			case 541:
+				goto tr819
 			case 543:
-				goto tr828
-			case 545:
-				goto tr833
-			case 546:
-				goto tr835
+				goto tr822
 			case 119:
+				goto tr173
+			case 545:
+				goto tr827
+			case 546:
+				goto tr829
+			case 120:
 				goto tr176
 			case 547:
-				goto tr839
+				goto tr833
 			case 549:
-				goto tr844
+				goto tr838
 			case 550:
-				goto tr846
-			case 120:
+				goto tr840
+			case 121:
 				goto tr178
 			case 551:
-				goto tr850
+				goto tr844
 			case 553:
-				goto tr854
+				goto tr849
 			case 554:
-				goto tr855
+				goto tr851
+			case 122:
+				goto tr180
 			case 555:
+				goto tr855
+			case 557:
 				goto tr859
+			case 558:
+				goto tr860
+			case 559:
+				goto tr864
 			}
 		}
 
@@ -28346,7 +28504,7 @@ func (lex *Lexer) Lex() *token.Token {
 		}
 	}
 
-	// line internal/php8/scanner.rl:511
+	// line internal/php8/scanner.rl:522
 
 	tkn.Value = lex.data[lex.ts:lex.te]
 	tkn.ID = token.ID(tok)

--- a/internal/php8/scanner.rl
+++ b/internal/php8/scanner.rl
@@ -60,7 +60,7 @@ func (lex *Lexer) Lex() *token.Token {
         dnum = (lnum?"." lnum)|(lnum"."lnum?);
         hnum = '0x'i[0-9a-fA-F]+('_'[0-9a-fA-F]+)*;
         bnum = '0b'i[01]+('_'[01]+)*;
-        onum = '0o'i[0-8]+('_'[0-8]+)*;
+        onum = '0o'i[0-7]+('_'[0-7]+)*;
 
         exponent_dnum = (lnum | dnum) ('e'|'E') ('+'|'-')? lnum;
         varname_first = [a-zA-Z_] | (0x0080..0x00FF);

--- a/internal/php8/scanner_php8_1_test.go
+++ b/internal/php8/scanner_php8_1_test.go
@@ -31,3 +31,127 @@ func TestReadonlyTokens(t *testing.T) {
 	}
 	suite.Run()
 }
+
+func TestNumberTokens(t *testing.T) {
+	suite := tester.NewLexerTokenStructTestSuite(t)
+	suite.UsePHP8()
+	suite.Code = `<?php
+0x10;
+0X10;
+0b10;
+0B10;
+0o10;
+0O10;
+`
+	suite.Expected = []*token.Token{
+		{
+			ID:    token.T_LNUMBER,
+			Value: []byte("0x10"),
+		},
+		{
+			ID:    ';',
+			Value: []byte(";"),
+		},
+		{
+			ID:    token.T_LNUMBER,
+			Value: []byte("0X10"),
+		},
+		{
+			ID:    ';',
+			Value: []byte(";"),
+		},
+		{
+			ID:    token.T_LNUMBER,
+			Value: []byte("0b10"),
+		},
+		{
+			ID:    ';',
+			Value: []byte(";"),
+		},
+		{
+			ID:    token.T_LNUMBER,
+			Value: []byte("0B10"),
+		},
+		{
+			ID:    ';',
+			Value: []byte(";"),
+		},
+		{
+			ID:    token.T_LNUMBER,
+			Value: []byte("0o10"),
+		},
+		{
+			ID:    ';',
+			Value: []byte(";"),
+		},
+		{
+			ID:    token.T_LNUMBER,
+			Value: []byte("0O10"),
+		},
+		{
+			ID:    ';',
+			Value: []byte(";"),
+		},
+	}
+	suite.Run()
+}
+
+func TestNumberStringTokens(t *testing.T) {
+	suite := tester.NewLexerTokenStructTestSuite(t)
+	suite.UsePHP8()
+	suite.Code = `<?php
+"$a[0o10]"
+"$a[0O10]"
+`
+	suite.Expected = []*token.Token{
+		{
+			ID:    '"',
+			Value: []byte("\""),
+		},
+		{
+			ID:    token.T_VARIABLE,
+			Value: []byte("$a"),
+		},
+		{
+			ID:    '[',
+			Value: []byte("["),
+		},
+		{
+			ID:    token.T_NUM_STRING,
+			Value: []byte("0o10"),
+		},
+		{
+			ID:    ']',
+			Value: []byte("]"),
+		},
+		{
+			ID:    '"',
+			Value: []byte("\""),
+		},
+		{
+			ID:    '"',
+			Value: []byte("\""),
+		},
+		{
+			ID:    token.T_VARIABLE,
+			Value: []byte("$a"),
+		},
+		{
+			ID:    '[',
+			Value: []byte("["),
+		},
+		{
+			ID:    token.T_NUM_STRING,
+			Value: []byte("0O10"),
+		},
+		{
+			ID:    ']',
+			Value: []byte("]"),
+		},
+		{
+			ID:    '"',
+			Value: []byte("\""),
+		},
+	}
+	suite.Run()
+}

--- a/pkg/visitor/printer/printer_php8_1_test.go
+++ b/pkg/visitor/printer/printer_php8_1_test.go
@@ -29,3 +29,14 @@ func TestNeverTypePHP81(t *testing.T) {
 function f(): never {}
 `)
 }
+
+func TestNumbersPHP81(t *testing.T) {
+	tester.NewParserPrintTestSuite(t).UsePHP8().Run(`<?php
+echo 0x10;
+echo 0X10;
+echo 0b10;
+echo 0B10;
+echo 0o10;
+echo 0O10;
+`)
+}


### PR DESCRIPTION
Also fixed a bug where `0X...` and `0B...` were not recognized as valid numbers.

FIxes #9 