### PR TITLE
php8.1: added final modifier for constants in class

### DIFF
--- a/pkg/visitor/printer/printer_php8_1_test.go
+++ b/pkg/visitor/printer/printer_php8_1_test.go
@@ -74,3 +74,13 @@ enum A implements B, C, D {
 }
 `)
 }
+
+func TestFinalConstantPHP81(t *testing.T) {
+	tester.NewParserPrintTestSuite(t).UsePHP8().Run(`<?php
+class Foo {
+    public const X = "foo";
+    final public const X = "foo";
+    final private const X = "foo";
+}
+`)
+}


### PR DESCRIPTION
This case is already covered by the existing grammar, so no changes are required.

Fixes #14 