### PR TITLE
Readme > Handle parse errors in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ func main() {
 	if err != nil {
 		log.Fatal("Error:" + err.Error())
 	}
+	
+	if len(parserErrors) > 0 {
+		for _, e := range parserErrors {
+			log.Println(e.String())
+		}
+		os.Exit(1)
+	}
 
 	// Dump
 


### PR DESCRIPTION
When playing with the parser I didn't notice the parser errors were ignored.